### PR TITLE
fix: GHA kind test update following MRO update

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -47,7 +47,7 @@ jobs:
           kubectl set env -n model-registry-operator-system deployment/model-registry-operator-controller-manager REST_IMAGE="${IMG}"
       - name: Create Test Registry
         run: |
-          kubectl apply -k "https://github.com/opendatahub-io/model-registry-operator.git/config/samples?ref=${BRANCH}"
+          kubectl apply -k "https://github.com/opendatahub-io/model-registry-operator.git/config/samples/postgres?ref=${BRANCH}"
           kubectl get mr
       - name: Wait for Test Registry Deployment
         run: |


### PR DESCRIPTION
realign to https://github.com/opendatahub-io/model-registry-operator/pull/60 following CI broken

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
