### PR TITLE
ci: configure Pull GH App bot to use tide label

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: main
+    upstream: kubeflow:main
+label: "tide/merge-merge"


### PR DESCRIPTION
To avoid potential forgetful events, ensure tide label is maintained for PR raised by Pull GH App.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
