### PR TITLE
py: update project version to v0.1.2

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-registry"
-version = "0.1.1"
+version = "0.1.2"
 description = "Client for Kubeflow Model Registry"
 authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
chore to update pyproject.toml to new release version, for similar in the past you can reference https://github.com/opendatahub-io/model-registry/pull/2