### PR TITLE
Update(scripts): Increase API version of Model Registry

### DIFF
--- a/openshift-ci/scripts/oci-model-registry-deploy.sh
+++ b/openshift-ci/scripts/oci-model-registry-deploy.sh
@@ -172,7 +172,7 @@ check_route_status() {
         fi
 
         # Test if the route is live
-        local response=$(curl -s -o /dev/null -w "%{http_code}" "$route_url/api/model_registry/v1alpha2/registered_models")
+        local response=$(curl -s -o /dev/null -w "%{http_code}" "$route_url/api/model_registry/v1alpha3/registered_models")
 
         # Check if the response status code is 200 OK or 404 Not Found
         if [[ "$response" == "200" ]]; then

--- a/test/scripts/rest.sh
+++ b/test/scripts/rest.sh
@@ -25,7 +25,7 @@ post_model_registry_data() {
   timestamp=$(date +"%Y%m%d%H%M%S")
   rm_name="demo-$timestamp"
 
-  rm_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha2/registered_models" '{
+  rm_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha3/registered_models" '{
     "description": "lorem ipsum registered model",
     "name": "'"$rm_name"'"
   }')
@@ -37,7 +37,7 @@ post_model_registry_data() {
     echo -e "${GREEN}✔ Success:${NC} Registered Model ID: $rm_id"
   fi
 
-  mv_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha2/model_versions" '{
+  mv_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha3/model_versions" '{
     "description": "lorem ipsum model version",
     "name": "v1",
     "author": "John Doe",
@@ -52,7 +52,7 @@ post_model_registry_data() {
   fi
 
   RAW_ML_MODEL_URI='https://huggingface.co/tarilabs/mnist/resolve/v1.nb20231206162408/mnist.onnx'
-  ma_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha2/model_versions/$mv_id/artifacts" '{
+  ma_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha3/model_versions/$mv_id/artifacts" '{
     "description": "lorem ipsum model artifact",
     "uri": "'"$RAW_ML_MODEL_URI"'",
     "name": "mnist",
@@ -103,7 +103,7 @@ EOF
 # Function to test Inference Service
 # TODO this will continue once we have MC PR merged from: https://github.com/opendatahub-io/odh-model-controller/pull/135
 inference_service() {
-  iss_mr=$(curl -s -X 'GET' "$MR_HOSTNAME/api/model_registry/v1alpha2/inference_services" \
+  iss_mr=$(curl -s -X 'GET' "$MR_HOSTNAME/api/model_registry/v1alpha3/inference_services" \
     -H 'accept: application/json')
 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We need to increase/change API version of Model Registry from `v1alpha2` to `v1alpha3` in testing scripts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Have `oc/kubectl` logged into Kubernetes/OpenShift cluster.
2. Run `./openshift-ci/scripts/oci-model-registry-deploy.sh` script.
3. You should see that script finished successfully.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
