### PR TITLE
periodic sync upstream KF to midstream ODH

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -33,7 +33,7 @@ jobs:
           VERSION: ${{ steps.tags.outputs.tag }}
         run: ./scripts/build_deploy.sh
       - name: Start Kind Cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.10.0
         with:
           node_image: "kindest/node:v1.27.11"
       - name: Load Local Registry Test Image

--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1033,6 +1033,8 @@ components:
         - $ref: "#/components/schemas/BaseResourceUpdate"
         - type: object
           properties:
+            owner:
+              type: string
             state:
               $ref: "#/components/schemas/RegisteredModelState"
     ModelVersion:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-registry"
-version = "0.1.0"
+version = "0.2.0a1"
 description = "Client for Kubeflow Model Registry"
 authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-registry"
-version = "0.2.0a1"
+version = "0.2.1a1"
 description = "Client for Kubeflow Model Registry"
 authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -129,11 +129,22 @@ class RegisteredModel(BaseContext):
 
     Attributes:
         name: Registered model name.
+        owner: Owner of this Registered Model.
         description: Description of the object.
         external_id: Customizable ID. Has to be unique among instances of the same type.
     """
 
     name: str
+    owner: str = None
+
+    @override
+    def map(self, type_id: int) -> Context:
+        mlmd_obj = super().map(type_id)
+        props = {
+            "owner": self.owner
+        }
+        self._map_props(props, mlmd_obj.properties)
+        return mlmd_obj
 
     @classmethod
     @override
@@ -142,4 +153,5 @@ class RegisteredModel(BaseContext):
         assert isinstance(
             py_obj, RegisteredModel
         ), f"Expected RegisteredModel, got {type(py_obj)}"
+        py_obj.owner = mlmd_obj.properties["owner"].string_value
         return py_obj

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -6,7 +6,7 @@ Todo:
 
 import pytest
 from ml_metadata.proto import Context
-from model_registry.types import ContextState, ModelVersion
+from model_registry.types import ContextState, ModelVersion, RegisteredModel
 
 from .. import Mapped
 
@@ -95,3 +95,40 @@ def test_full_model_version_unmapping(full_model_version: Mapped):
     assert unmapped_version.author == py_version.author
     assert unmapped_version.state == py_version.state
     assert unmapped_version.metadata == py_version.metadata
+
+
+@pytest.fixture()
+def minimal_registered_model() -> Mapped:
+    proto_version = Context(
+        name="mnist",
+        type_id=1,
+        external_id="test_external_id")
+    proto_version.properties["description"].string_value = "test description"
+    proto_version.properties["state"].string_value = "LIVE"
+    proto_version.properties["owner"].string_value = "my owner"
+
+    py_regmodel = RegisteredModel(name="mnist",
+        owner="my owner",
+        external_id="test_external_id",
+        description="test description")
+    return Mapped(proto_version, py_regmodel)
+
+
+def test_minimal_registered_model_mapping(minimal_registered_model: Mapped):
+    mapped_version = minimal_registered_model.py.map(1)
+    proto_version = minimal_registered_model.proto
+    assert mapped_version.name == proto_version.name
+    assert mapped_version.type_id == proto_version.type_id
+    assert mapped_version.external_id == proto_version.external_id
+    assert mapped_version.properties == proto_version.properties
+    assert mapped_version.custom_properties == proto_version.custom_properties
+
+
+def test_minimal_registered_model_unmapping(minimal_registered_model: Mapped):
+    unmapped_regmodel = RegisteredModel.unmap(minimal_registered_model.proto)
+    py_regmodel = minimal_registered_model.py
+    assert unmapped_regmodel.name == py_regmodel.name
+    assert unmapped_regmodel.owner == py_regmodel.owner
+    assert unmapped_regmodel.description == py_regmodel.description
+    assert unmapped_regmodel.external_id == py_regmodel.external_id
+    assert unmapped_regmodel.state == py_regmodel.state

--- a/docs/logical_model.md
+++ b/docs/logical_model.md
@@ -442,10 +442,12 @@ This diagram summarizes the relationship between the entities:
 classDiagram
     class RegisteredModel{
         +String name
+        +String owner
         +Map customProperties
     }
     class ModelVersion{
         +String name
+        +String author
         +Map customProperties
     }
     class Artifact{

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -173,6 +173,7 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertRegisteredModel(source *proto.Contex
 		openapiRegisteredModel.Id = converter.Int64ToString((*source).Id)
 		openapiRegisteredModel.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiRegisteredModel.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
+		openapiRegisteredModel.Owner = converter.MapOwner((*source).Properties)
 		openapiRegisteredModel.State = converter.MapRegisteredModelState((*source).Properties)
 		pOpenapiRegisteredModel = &openapiRegisteredModel
 	}

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -379,6 +379,12 @@ func (c *OpenAPIConverterImpl) ConvertRegisteredModelCreate(source *openapi.Regi
 			pString3 = &xstring3
 		}
 		openapiRegisteredModel.Name = pString3
+		var pString4 *string
+		if (*source).Owner != nil {
+			xstring4 := *(*source).Owner
+			pString4 = &xstring4
+		}
+		openapiRegisteredModel.Owner = pString4
 		var pOpenapiRegisteredModelState *openapi.RegisteredModelState
 		if (*source).State != nil {
 			openapiRegisteredModelState := openapi.RegisteredModelState(*(*source).State)
@@ -414,6 +420,12 @@ func (c *OpenAPIConverterImpl) ConvertRegisteredModelUpdate(source *openapi.Regi
 			pString2 = &xstring2
 		}
 		openapiRegisteredModel.ExternalId = pString2
+		var pString3 *string
+		if (*source).Owner != nil {
+			xstring3 := *(*source).Owner
+			pString3 = &xstring3
+		}
+		openapiRegisteredModel.Owner = pString3
 		var pOpenapiRegisteredModelState *openapi.RegisteredModelState
 		if (*source).State != nil {
 			openapiRegisteredModelState := openapi.RegisteredModelState(*(*source).State)

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -414,6 +414,20 @@ func TestMapDescription(t *testing.T) {
 	assertion.Equal("my-description", *extracted)
 }
 
+func TestMapOwner(t *testing.T) {
+	assertion := setup(t)
+
+	extracted := MapOwner(map[string]*proto.Value{
+		"owner": {
+			Value: &proto.Value_StringValue{
+				StringValue: "my-owner",
+			},
+		},
+	})
+
+	assertion.Equal("my-owner", *extracted)
+}
+
 func TestPropertyRuntime(t *testing.T) {
 	assertion := setup(t)
 

--- a/internal/converter/mlmd_openapi_converter.go
+++ b/internal/converter/mlmd_openapi_converter.go
@@ -15,6 +15,7 @@ import (
 // goverter:extend MapMLMDCustomProperties
 type MLMDToOpenAPIConverter interface {
 	// goverter:map Properties Description | MapDescription
+	// goverter:map Properties Owner | MapOwner
 	// goverter:map Properties State | MapRegisteredModelState
 	ConvertRegisteredModel(source *proto.Context) (*openapi.RegisteredModel, error)
 

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -211,6 +211,10 @@ func MapDescription(properties map[string]*proto.Value) *string {
 	return MapStringProperty(properties, "description")
 }
 
+func MapOwner(properties map[string]*proto.Value) *string {
+	return MapStringProperty(properties, "owner")
+}
+
 func MapModelArtifactFormatName(properties map[string]*proto.Value) *string {
 	return MapStringProperty(properties, "model_format_name")
 }

--- a/internal/converter/openapi_converter.go
+++ b/internal/converter/openapi_converter.go
@@ -52,7 +52,7 @@ type OpenAPIConverter interface {
 	// Ignore all fields that ARE editable
 	// goverter:default InitRegisteredModelWithUpdate
 	// goverter:autoMap Existing
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalId CustomProperties State
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalId CustomProperties State Owner
 	OverrideNotEditableForRegisteredModel(source OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error)
 
 	// Ignore all fields that ARE editable

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -123,6 +123,14 @@ func PrefixWhenOwned(ownerId *string, entityName string) string {
 func MapRegisteredModelProperties(source *openapi.RegisteredModel) (map[string]*proto.Value, error) {
 	props := make(map[string]*proto.Value)
 	if source != nil {
+		if source.Owner != nil {
+			props["owner"] = &proto.Value{
+				Value: &proto.Value_StringValue{
+					StringValue: *source.Owner,
+				},
+			}
+		}
+
 		if source.Description != nil {
 			props["description"] = &proto.Value{
 				Value: &proto.Value_StringValue{

--- a/internal/mlmdtypes/mlmdtypes.go
+++ b/internal/mlmdtypes/mlmdtypes.go
@@ -44,6 +44,7 @@ func CreateMLMDTypes(cc grpc.ClientConnInterface, nameConfig MLMDTypeNamesConfig
 			Name: &nameConfig.RegisteredModelTypeName,
 			Properties: map[string]proto.PropertyType{
 				"description": proto.PropertyType_STRING,
+				"owner":       proto.PropertyType_STRING,
 				"state":       proto.PropertyType_STRING,
 			},
 		},

--- a/manifests/kustomize/OWNERS
+++ b/manifests/kustomize/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - tarilabs
+  - rareddy
+  - Tomcli
+reviewers:
+  - tarilabs
+  - rareddy
+  - Tomcli

--- a/manifests/kustomize/OWNERS
+++ b/manifests/kustomize/OWNERS
@@ -1,8 +1,6 @@
 approvers:
   - tarilabs
   - rareddy
-  - Tomcli
 reviewers:
   - tarilabs
   - rareddy
-  - Tomcli

--- a/manifests/kustomize/README.md
+++ b/manifests/kustomize/README.md
@@ -1,0 +1,56 @@
+# Install Kubeflow Model Registry
+
+This folder contains [Kubeflow Model Registry](https://www.kubeflow.org/docs/components/model-registry/installation/) Kustomize manifests
+
+## Installation
+
+To install Kubeflow Model Registry, follow [Kubeflow Model Registry deployment documentation](https://www.kubeflow.org/docs/components/model-registry/installation/)
+
+The following instructions will summarize how to deploy Model Registry as separate component in the context of a default Kubeflow >=1.8 installation.
+
+```bash
+kubectl apply -k overlays/db
+```
+
+As the default Kubeflow installation provides an Istio mesh, apply the necessary manifests:
+
+```bash
+kubectl apply -k options/istio
+```
+
+Check everything is up and running:
+
+```bash
+kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=2m
+kubectl logs -n kubeflow deployment/model-registry-deployment
+```
+
+Optionally, you can also port-forward the REST API container port of Model Registry to interact with it from your terminal:
+
+```bash
+kubectl port-forward svc/model-registry-service -n kubeflow 8081:8080
+```
+
+And then, from another terminal:
+
+```bash
+curl -sX 'GET' \
+  'http://localhost:8081/api/model_registry/v1alpha3/registered_models?pageSize=100&orderBy=ID&sortOrder=DESC' \
+  -H 'accept: application/json' | jq
+```
+
+## Usage
+
+For a basic usage of the Kubeflow Model Registry, follow the [Kubeflow Model Registry getting started documentation](https://www.kubeflow.org/docs/components/model-registry/getting-started/)
+
+## Uninstall
+
+To uninstall the Kubeflow Model Registry run:
+
+```bash
+# Delete istio options
+kubectl delete -k options/istio
+
+# Delete model registry db and deployment
+kubectl delete -k overlays/db
+```

--- a/pkg/openapi/model_registered_model.go
+++ b/pkg/openapi/model_registered_model.go
@@ -33,6 +33,7 @@ type RegisteredModel struct {
 	CreateTimeSinceEpoch *string `json:"createTimeSinceEpoch,omitempty"`
 	// Output only. Last update time of the resource since epoch in millisecond since epoch.
 	LastUpdateTimeSinceEpoch *string               `json:"lastUpdateTimeSinceEpoch,omitempty"`
+	Owner                    *string               `json:"owner,omitempty"`
 	State                    *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -281,6 +282,38 @@ func (o *RegisteredModel) SetLastUpdateTimeSinceEpoch(v string) {
 	o.LastUpdateTimeSinceEpoch = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModel) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModel) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModel) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModel) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModel) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -343,6 +376,9 @@ func (o RegisteredModel) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.LastUpdateTimeSinceEpoch) {
 		toSerialize["lastUpdateTimeSinceEpoch"] = o.LastUpdateTimeSinceEpoch
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/pkg/openapi/model_registered_model_create.go
+++ b/pkg/openapi/model_registered_model_create.go
@@ -27,6 +27,7 @@ type RegisteredModelCreate struct {
 	ExternalId *string `json:"externalId,omitempty"`
 	// The client provided name of the artifact. This field is optional. If set, it must be unique among all the artifacts of the same artifact type within a database instance and cannot be changed once set.
 	Name  *string               `json:"name,omitempty"`
+	Owner *string               `json:"owner,omitempty"`
 	State *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -179,6 +180,38 @@ func (o *RegisteredModelCreate) SetName(v string) {
 	o.Name = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModelCreate) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModelCreate) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModelCreate) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModelCreate) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModelCreate) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -232,6 +265,9 @@ func (o RegisteredModelCreate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/pkg/openapi/model_registered_model_update.go
+++ b/pkg/openapi/model_registered_model_update.go
@@ -25,6 +25,7 @@ type RegisteredModelUpdate struct {
 	Description *string `json:"description,omitempty"`
 	// The external id that come from the clients’ system. This field is optional. If set, it must be unique among all resources within a database instance.
 	ExternalId *string               `json:"externalId,omitempty"`
+	Owner      *string               `json:"owner,omitempty"`
 	State      *RegisteredModelState `json:"state,omitempty"`
 }
 
@@ -145,6 +146,38 @@ func (o *RegisteredModelUpdate) SetExternalId(v string) {
 	o.ExternalId = &v
 }
 
+// GetOwner returns the Owner field value if set, zero value otherwise.
+func (o *RegisteredModelUpdate) GetOwner() string {
+	if o == nil || IsNil(o.Owner) {
+		var ret string
+		return ret
+	}
+	return *o.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RegisteredModelUpdate) GetOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.Owner) {
+		return nil, false
+	}
+	return o.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (o *RegisteredModelUpdate) HasOwner() bool {
+	if o != nil && !IsNil(o.Owner) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner gets a reference to the given string and assigns it to the Owner field.
+func (o *RegisteredModelUpdate) SetOwner(v string) {
+	o.Owner = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *RegisteredModelUpdate) GetState() RegisteredModelState {
 	if o == nil || IsNil(o.State) {
@@ -195,6 +228,9 @@ func (o RegisteredModelUpdate) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ExternalId) {
 		toSerialize["externalId"] = o.ExternalId
+	}
+	if !IsNil(o.Owner) {
+		toSerialize["owner"] = o.Owner
 	}
 	if !IsNil(o.State) {
 		toSerialize["state"] = o.State

--- a/test/robot/UserStory.robot
+++ b/test/robot/UserStory.robot
@@ -80,3 +80,10 @@ As a MLOps engineer I would like to store some labels
     ${r}  Then I get ModelArtifactByID    id=${aId}
           And Should be equal    ${r["description"]}    sed do eiusmod tempor incididunt
           And Dictionaries Should Be Equal   ${r["customProperties"]}  ${cp3}
+
+As a MLOps engineer I would like to store an owner for the RegisteredModel
+    Set To Dictionary    ${registered_model}    description=Lorem ipsum dolor sit amet  name=${name}  owner=My owner
+    ${rId}  Given I create a RegisteredModel    payload=${registered_model}
+    ${r}  Then I get RegisteredModelByID    id=${rId}
+          And Should be equal    ${r["description"]}    Lorem ipsum dolor sit amet
+          And Should be equal    ${r["owner"]}    My owner


### PR DESCRIPTION
- keep https://github.com/kubeflow/model-registry/pull/71 (resolve conflicts)
- keep https://github.com/kubeflow/model-registry/pull/72
- keep https://github.com/kubeflow/model-registry/pull/70
- keep https://github.com/kubeflow/model-registry/pull/73
- keep https://github.com/kubeflow/model-registry/pull/69
- resolve conflicts on https://github.com/kubeflow/model-registry/pull/71 (ODH midstream was ahead in pypi version, as we didn't maintain the pypi version upstream, so upstream was "lagging behind" actual published versions, now upstream should flow to midstream)