### PR TITLE
Istio sample update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Unit tests
         run: make test-cover
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v4.5.0
         with:
           files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -61,13 +61,12 @@ jobs:
             nox --python=${{ matrix.python }}
           fi
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.5.0
         if: always() && matrix.session == 'tests'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: coverage.xml
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload documentation
         if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ __pycache__
 # Protoc files
 include/
 readme.txt
+
+# do not send certs
+certs/

--- a/openshift-ci/resources/model-registry-DSCInitialization.yaml
+++ b/openshift-ci/resources/model-registry-DSCInitialization.yaml
@@ -14,3 +14,20 @@ metadata:
   name: default-dsci
 spec:
   applicationsNamespace: opendatahub
+  devFlags:
+    logmode: production
+  monitoring:
+    managementState: Managed
+    namespace: opendatahub
+  serviceMesh:
+    auth:
+      audiences:
+      - https://kubernetes.default.svc
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed
+  trustedCABundle:
+    customCABundle: ""
+    managementState: Managed

--- a/openshift-ci/resources/opendatahub-subscription.yaml
+++ b/openshift-ci/resources/opendatahub-subscription.yaml
@@ -8,3 +8,4 @@ spec:
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
+  # startingCSV: opendatahub-operator.v2.12.0

--- a/openshift-ci/resources/opendatahub-subscription.yaml
+++ b/openshift-ci/resources/opendatahub-subscription.yaml
@@ -8,4 +8,4 @@ spec:
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  # startingCSV: opendatahub-operator.v2.12.0
+  

--- a/openshift-ci/resources/samples/authorino-subscription.yaml
+++ b/openshift-ci/resources/samples/authorino-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: authorino-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: authorino-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/openshift-ci/resources/samples/istio/components/authconfig-labels.yaml
+++ b/openshift-ci/resources/samples/istio/components/authconfig-labels.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/istio/authConfigLabels
+  value:
+    security.opendatahub.io/authorization-group: default

--- a/openshift-ci/resources/samples/istio/components/istio.env
+++ b/openshift-ci/resources/samples/istio/components/istio.env
@@ -1,0 +1,5 @@
+AUTH_PROVIDER=opendatahub-auth-provider
+ISTIO_INGRESS=ingressgateway
+DOMAIN=apps.rk415.apicurio.integration-qe.com
+REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
+GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential

--- a/openshift-ci/resources/samples/istio/components/istio_modelregistry.yaml
+++ b/openshift-ci/resources/samples/istio/components/istio_modelregistry.yaml
@@ -1,0 +1,15 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  istio:
+    authProvider: AUTH_PROVIDER
+    authConfigLabels: {}
+    gateway:
+      domain: DOMAIN
+      istioIngress: ISTIO_INGRESS
+      rest:
+        gatewayRoute: enabled
+      grpc:
+        gatewayRoute: enabled

--- a/openshift-ci/resources/samples/istio/components/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/components/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Istio config patch
+patches:
+  - path: istio_modelregistry.yaml
+  - target:
+      group: modelregistry.opendatahub.io
+      version: v1alpha1
+      kind: ModelRegistry
+      name: modelregistry-sample
+    path: authconfig-labels.yaml
+
+# Config map and replacements to use istio.env for cluster specific config
+configMapGenerator:
+  - envs:
+      - istio.env
+    files:
+      - authconfig-labels.yaml
+    name: modelregistry-sample-environment
+generatorOptions:
+  disableNameSuffixHash: true
+replacements:
+  - path: replacements.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/istio/components/replacements.yaml
+++ b/openshift-ci/resources/samples/istio/components/replacements.yaml
@@ -1,0 +1,32 @@
+# replacements from configmap using istio.env for cluster specific config
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.AUTH_PROVIDER
+  targets:
+    - select:
+        apiVersion: modelregistry.opendatahub.io/v1alpha1
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.authProvider
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.DOMAIN
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.domain
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.ISTIO_INGRESS
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.istioIngress

--- a/openshift-ci/resources/samples/istio/components/tls/istio_tls_modelregistry.yaml
+++ b/openshift-ci/resources/samples/istio/components/tls/istio_tls_modelregistry.yaml
@@ -1,0 +1,13 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  istio:
+    gateway:
+      rest:
+        tls:
+          credentialName: REST_CREDENTIAL_NAME
+      grpc:
+        tls:
+          credentialName: GRPC_CREDENTIAL_NAME

--- a/openshift-ci/resources/samples/istio/components/tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/components/tls/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+## Append samples of your project ##
+
+# Istio tls config patch
+patches:
+  - path: istio_tls_modelregistry.yaml
+
+replacements:
+  - path: tls-replacements.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/istio/components/tls/tls-replacements.yaml
+++ b/openshift-ci/resources/samples/istio/components/tls/tls-replacements.yaml
@@ -1,0 +1,21 @@
+# replacements from configmap using istio.env for cluster specific config
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.REST_CREDENTIAL_NAME
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.rest.tls.credentialName
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.GRPC_CREDENTIAL_NAME
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.grpc.tls.credentialName

--- a/openshift-ci/resources/samples/istio/mysql-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/mysql-tls/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../mysql
+
+components:
+  - ../components/tls
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/istio/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/mysql/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+- ../../mysql
+
+components:
+- ../components
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/istio/postgres-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/postgres-tls/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../postgres
+
+components:
+  - ../components/tls
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/istio/postgres/kustomization.yaml
+++ b/openshift-ci/resources/samples/istio/postgres/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../postgres
+
+components:
+  - ../components
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/mysql/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+- mysql-db.yaml
+- modelregistry_v1alpha1_modelregistry.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
+++ b/openshift-ci/resources/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
@@ -1,0 +1,24 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  labels:
+    app.kubernetes.io/name: modelregistry
+    app.kubernetes.io/instance: modelregistry-sample
+    app.kubernetes.io/part-of: model-registry-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: model-registry-operator
+  name: modelregistry-sample
+spec:
+  # TODO(user): Add fields here
+  grpc:
+    port: 9090
+  rest:
+    port: 8080
+    serviceRoute: disabled
+  mysql:
+    host: model-registry-db
+    database: model_registry
+    username: mlmduser
+    passwordSecret:
+      name: model-registry-db
+      key: database-password

--- a/openshift-ci/resources/samples/mysql/mysql-db.yaml
+++ b/openshift-ci/resources/samples/mysql/mysql-db.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}
+    name: model-registry-db
+  spec:
+    ports:
+    - name: mysql
+      nodePort: 0
+      port: 3306
+      protocol: TCP
+      appProtocol: tcp
+      targetPort: 3306
+    selector:
+      name: model-registry-db
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: model-registry-db
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: model-registry-db
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 0
+    selector:
+      matchLabels:
+        name: model-registry-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: model-registry-db
+          sidecar.istio.io/inject: "false"
+      spec:
+        containers:
+        - env:
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: model-registry-db
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: MYSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: model-registry-db
+          args:
+            - --datadir
+            - /var/lib/mysql/datadir
+            - --default-authentication-plugin=mysql_native_password
+          image: mysql:8.3.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - mysqladmin -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} ping
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: mysql
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - mysql -D ${MYSQL_DATABASE} -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/mysql
+            name: model-registry-db-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: model-registry-db-data
+          persistentVolumeClaim:
+            claimName: model-registry-db
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: model-registry-db
+  stringData:
+    database-name: "model_registry"
+    database-password: "TheBlurstOfTimes"
+    database-user: "mlmduser"
+kind: List
+metadata: {}

--- a/openshift-ci/resources/samples/postgres/kustomization.yaml
+++ b/openshift-ci/resources/samples/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+## Append samples of your project ##
+resources:
+- postgres-db.yaml
+- modelregistry_v1alpha1_modelregistry.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/postgres/modelregistry_v1alpha1_modelregistry.yaml
+++ b/openshift-ci/resources/samples/postgres/modelregistry_v1alpha1_modelregistry.yaml
@@ -1,0 +1,24 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  labels:
+    app.kubernetes.io/name: modelregistry
+    app.kubernetes.io/instance: modelregistry-sample
+    app.kubernetes.io/part-of: model-registry-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: model-registry-operator
+  name: modelregistry-sample
+spec:
+  # TODO(user): Add fields here
+  grpc:
+    port: 9090
+  rest:
+    port: 8080
+    serviceRoute: disabled
+  postgres:
+    host: model-registry-db
+    database: model-registry
+    username: mlmduser
+    passwordSecret:
+      name: model-registry-db
+      key: database-password

--- a/openshift-ci/resources/samples/postgres/postgres-db.yaml
+++ b/openshift-ci/resources/samples/postgres/postgres-db.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\postgresql\)].port}
+    name: model-registry-db
+  spec:
+    ports:
+    - name: postgresql
+      nodePort: 0
+      port: 5432
+      protocol: TCP
+      appProtocol: tcp
+      targetPort: 5432
+    selector:
+      name: model-registry-db
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: model-registry-db
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: model-registry-db
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 0
+    selector:
+      matchLabels:
+        name: model-registry-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: model-registry-db
+          sidecar.istio.io/inject: "false"
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: model-registry-db
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: model-registry-db
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - "-c"
+                - "/usr/bin/pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"
+            initialDelaySeconds: 30
+            timeoutSeconds: 2
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - "-c"
+                - "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: model-registry-db-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: model-registry-db-data
+          persistentVolumeClaim:
+            claimName: model-registry-db
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: model-registry-db
+  stringData:
+    database-name: "model-registry"
+    database-password: "TheBlurstOfTimes"
+    database-user: "mlmduser"
+kind: List
+metadata: {}

--- a/openshift-ci/resources/samples/samples/istio/components/authconfig-labels.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/authconfig-labels.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/istio/authConfigLabels
+  value:
+    security.opendatahub.io/authorization-group: default

--- a/openshift-ci/resources/samples/samples/istio/components/istio.env
+++ b/openshift-ci/resources/samples/samples/istio/components/istio.env
@@ -1,0 +1,5 @@
+AUTH_PROVIDER=opendatahub-auth-provider
+DOMAIN=my-domain
+ISTIO_INGRESS=ingressgateway
+REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
+GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential

--- a/openshift-ci/resources/samples/samples/istio/components/istio_modelregistry.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/istio_modelregistry.yaml
@@ -1,0 +1,15 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  istio:
+    authProvider: AUTH_PROVIDER
+    authConfigLabels: {}
+    gateway:
+      domain: DOMAIN
+      istioIngress: ISTIO_INGRESS
+      rest:
+        gatewayRoute: enabled
+      grpc:
+        gatewayRoute: enabled

--- a/openshift-ci/resources/samples/samples/istio/components/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Istio config patch
+patches:
+  - path: istio_modelregistry.yaml
+  - target:
+      group: modelregistry.opendatahub.io
+      version: v1alpha1
+      kind: ModelRegistry
+      name: modelregistry-sample
+    path: authconfig-labels.yaml
+
+# Config map and replacements to use istio.env for cluster specific config
+configMapGenerator:
+  - envs:
+      - istio.env
+    files:
+      - authconfig-labels.yaml
+    name: modelregistry-sample-environment
+generatorOptions:
+  disableNameSuffixHash: true
+replacements:
+  - path: replacements.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/istio/components/replacements.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/replacements.yaml
@@ -1,0 +1,32 @@
+# replacements from configmap using istio.env for cluster specific config
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.AUTH_PROVIDER
+  targets:
+    - select:
+        apiVersion: modelregistry.opendatahub.io/v1alpha1
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.authProvider
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.DOMAIN
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.domain
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.ISTIO_INGRESS
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.istioIngress

--- a/openshift-ci/resources/samples/samples/istio/components/tls/istio_tls_modelregistry.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/tls/istio_tls_modelregistry.yaml
@@ -1,0 +1,13 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  istio:
+    gateway:
+      rest:
+        tls:
+          credentialName: REST_CREDENTIAL_NAME
+      grpc:
+        tls:
+          credentialName: GRPC_CREDENTIAL_NAME

--- a/openshift-ci/resources/samples/samples/istio/components/tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/tls/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+## Append samples of your project ##
+
+# Istio tls config patch
+patches:
+  - path: istio_tls_modelregistry.yaml
+
+replacements:
+  - path: tls-replacements.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/istio/components/tls/tls-replacements.yaml
+++ b/openshift-ci/resources/samples/samples/istio/components/tls/tls-replacements.yaml
@@ -1,0 +1,21 @@
+# replacements from configmap using istio.env for cluster specific config
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.REST_CREDENTIAL_NAME
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.rest.tls.credentialName
+- source:
+    kind: ConfigMap
+    name: modelregistry-sample-environment
+    fieldPath: data.GRPC_CREDENTIAL_NAME
+  targets:
+    - select:
+        kind: ModelRegistry
+        name: modelregistry-sample
+      fieldPaths:
+        - spec.istio.gateway.grpc.tls.credentialName

--- a/openshift-ci/resources/samples/samples/istio/mysql-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/mysql-tls/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../mysql
+
+components:
+  - ../components/tls
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/istio/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/mysql/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+- ../../mysql
+
+components:
+- ../components
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/istio/postgres-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/postgres-tls/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../postgres
+
+components:
+  - ../components/tls
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/istio/postgres/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/istio/postgres/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../postgres
+
+components:
+  - ../components
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/mysql/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+- mysql-db.yaml
+- modelregistry_v1alpha1_modelregistry.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
+++ b/openshift-ci/resources/samples/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
@@ -1,0 +1,24 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  labels:
+    app.kubernetes.io/name: modelregistry
+    app.kubernetes.io/instance: modelregistry-sample
+    app.kubernetes.io/part-of: model-registry-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: model-registry-operator
+  name: modelregistry-sample
+spec:
+  # TODO(user): Add fields here
+  grpc:
+    port: 9090
+  rest:
+    port: 8080
+    serviceRoute: disabled
+  mysql:
+    host: model-registry-db
+    database: model_registry
+    username: mlmduser
+    passwordSecret:
+      name: model-registry-db
+      key: database-password

--- a/openshift-ci/resources/samples/samples/mysql/mysql-db.yaml
+++ b/openshift-ci/resources/samples/samples/mysql/mysql-db.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}
+    name: model-registry-db
+  spec:
+    ports:
+    - name: mysql
+      nodePort: 0
+      port: 3306
+      protocol: TCP
+      appProtocol: tcp
+      targetPort: 3306
+    selector:
+      name: model-registry-db
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: model-registry-db
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: model-registry-db
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 0
+    selector:
+      matchLabels:
+        name: model-registry-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: model-registry-db
+          sidecar.istio.io/inject: "false"
+      spec:
+        containers:
+        - env:
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: model-registry-db
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: MYSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: model-registry-db
+          args:
+            - --datadir
+            - /var/lib/mysql/datadir
+            - --default-authentication-plugin=mysql_native_password
+          image: mysql:8.3.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - mysqladmin -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} ping
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: mysql
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - mysql -D ${MYSQL_DATABASE} -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/mysql
+            name: model-registry-db-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: model-registry-db-data
+          persistentVolumeClaim:
+            claimName: model-registry-db
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: model-registry-db
+  stringData:
+    database-name: "model_registry"
+    database-password: "TheBlurstOfTimes"
+    database-user: "mlmduser"
+kind: List
+metadata: {}

--- a/openshift-ci/resources/samples/samples/postgres/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+## Append samples of your project ##
+resources:
+- postgres-db.yaml
+- modelregistry_v1alpha1_modelregistry.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/postgres/modelregistry_v1alpha1_modelregistry.yaml
+++ b/openshift-ci/resources/samples/samples/postgres/modelregistry_v1alpha1_modelregistry.yaml
@@ -1,0 +1,24 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  labels:
+    app.kubernetes.io/name: modelregistry
+    app.kubernetes.io/instance: modelregistry-sample
+    app.kubernetes.io/part-of: model-registry-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: model-registry-operator
+  name: modelregistry-sample
+spec:
+  # TODO(user): Add fields here
+  grpc:
+    port: 9090
+  rest:
+    port: 8080
+    serviceRoute: disabled
+  postgres:
+    host: model-registry-db
+    database: model-registry
+    username: mlmduser
+    passwordSecret:
+      name: model-registry-db
+      key: database-password

--- a/openshift-ci/resources/samples/samples/postgres/postgres-db.yaml
+++ b/openshift-ci/resources/samples/samples/postgres/postgres-db.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\postgresql\)].port}
+    name: model-registry-db
+  spec:
+    ports:
+    - name: postgresql
+      nodePort: 0
+      port: 5432
+      protocol: TCP
+      appProtocol: tcp
+      targetPort: 5432
+    selector:
+      name: model-registry-db
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: model-registry-db
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: model-registry-db
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 0
+    selector:
+      matchLabels:
+        name: model-registry-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: model-registry-db
+          sidecar.istio.io/inject: "false"
+      spec:
+        containers:
+        - env:
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: model-registry-db
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: model-registry-db
+          - name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: model-registry-db
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+          image: postgres:16
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - "-c"
+                - "/usr/bin/pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"
+            initialDelaySeconds: 30
+            timeoutSeconds: 2
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - "-c"
+                - "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/postgresql/data
+            name: model-registry-db-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: model-registry-db-data
+          persistentVolumeClaim:
+            claimName: model-registry-db
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: model-registry-db
+  stringData:
+    database-name: "model-registry"
+    database-password: "TheBlurstOfTimes"
+    database-user: "mlmduser"
+kind: List
+metadata: {}

--- a/openshift-ci/resources/samples/samples/secure-db/components/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/components/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Istio config patch
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+    path: model-registry-db-secrets.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/secure-db/components/model-registry-db-secrets.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/components/model-registry-db-secrets.yaml
@@ -1,0 +1,15 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    # name must match the volume name below
+    name: server-cert
+    mountPath: /etc/server-cert
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    # The secret data is exposed to Containers in the Pod through a Volume.
+    name: server-cert
+    secret:
+      secretName: model-registry-db-credential
+      defaultMode: 0600

--- a/openshift-ci/resources/samples/samples/secure-db/components/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/components/mysql/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+## Append samples of your project ##
+
+# MySQL tls args patch
+patches:
+  - path: mysql-ssl-args.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+  - path: secure_mysql_modelregistry.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/secure-db/components/mysql/mysql-ssl-args.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/components/mysql/mysql-ssl-args.yaml
@@ -1,0 +1,16 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-ca=/etc/server-cert/ca.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-cert=/etc/server-cert/tls.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-key=/etc/server-cert/tls.key
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --require-secure-transport

--- a/openshift-ci/resources/samples/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
@@ -1,0 +1,9 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  mysql:
+    sslRootCertificateSecret:
+      name: model-registry-db-credential
+      key: ca.crt

--- a/openshift-ci/resources/samples/samples/secure-db/mysql-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/mysql-tls/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../istio/mysql-tls
+
+components:
+  - ../components
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/samples/secure-db/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/samples/secure-db/mysql/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../mysql
+
+components:
+  - ../components/
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/secure-db/components/kustomization.yaml
+++ b/openshift-ci/resources/samples/secure-db/components/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Istio config patch
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+    path: model-registry-db-secrets.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/secure-db/components/model-registry-db-secrets.yaml
+++ b/openshift-ci/resources/samples/secure-db/components/model-registry-db-secrets.yaml
@@ -1,0 +1,15 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    # name must match the volume name below
+    name: server-cert
+    mountPath: /etc/server-cert
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    # The secret data is exposed to Containers in the Pod through a Volume.
+    name: server-cert
+    secret:
+      secretName: model-registry-db-credential
+      defaultMode: 0600

--- a/openshift-ci/resources/samples/secure-db/components/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/secure-db/components/mysql/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+## Append samples of your project ##
+
+# MySQL tls args patch
+patches:
+  - path: mysql-ssl-args.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-db
+  - path: secure_mysql_modelregistry.yaml
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/secure-db/components/mysql/mysql-ssl-args.yaml
+++ b/openshift-ci/resources/samples/secure-db/components/mysql/mysql-ssl-args.yaml
@@ -1,0 +1,16 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-ca=/etc/server-cert/ca.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-cert=/etc/server-cert/tls.crt
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --ssl-key=/etc/server-cert/tls.key
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --require-secure-transport

--- a/openshift-ci/resources/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
+++ b/openshift-ci/resources/samples/secure-db/components/mysql/secure_mysql_modelregistry.yaml
@@ -1,0 +1,9 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: modelregistry-sample
+spec:
+  mysql:
+    sslRootCertificateSecret:
+      name: model-registry-db-credential
+      key: ca.crt

--- a/openshift-ci/resources/samples/secure-db/mysql-tls/kustomization.yaml
+++ b/openshift-ci/resources/samples/secure-db/mysql-tls/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../istio/mysql-tls
+
+components:
+  - ../components
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/secure-db/mysql/kustomization.yaml
+++ b/openshift-ci/resources/samples/secure-db/mysql/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+## Append samples of your project ##
+resources:
+  - ../../mysql
+
+components:
+  - ../components/
+  - ../components/mysql
+
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/openshift-ci/resources/samples/service-mesh-subscription.yaml
+++ b/openshift-ci/resources/samples/service-mesh-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/openshift-ci/scripts/generate_certs.sh
+++ b/openshift-ci/scripts/generate_certs.sh
@@ -1,0 +1,16 @@
+DOMAIN=$1
+mkdir -p certs
+# create CA cert
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/O=modelregistry Inc./CN=$DOMAIN" -keyout certs/domain.key -out certs/domain.crt
+# create rest cert and private key
+echo "subjectAltName = DNS:modelregistry-sample-rest.$DOMAIN" > certs/modelregistry-sample-rest.domain.ext
+openssl req -out certs/modelregistry-sample-rest.domain.csr -newkey rsa:2048 -nodes -keyout certs/modelregistry-sample-rest.domain.key -subj "/CN=modelregistry-sample-rest/O=modelregistry organization" -addext "subjectAltName = DNS:modelregistry-sample-rest.$DOMAIN"
+openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key -set_serial 0 -in certs/modelregistry-sample-rest.domain.csr -out certs/modelregistry-sample-rest.domain.crt -extfile certs/modelregistry-sample-rest.domain.ext
+# create grpc cert and private key
+echo "subjectAltName = DNS:modelregistry-sample-grpc.$DOMAIN" > certs/modelregistry-sample-grpc.domain.ext
+openssl req -out certs/modelregistry-sample-grpc.domain.csr -newkey rsa:2048 -nodes -keyout certs/modelregistry-sample-grpc.domain.key -subj "/CN=modelregistry-sample-grpc/O=modelregistry organization" -addext "subjectAltName = DNS:modelregistry-sample-grpc.$DOMAIN"
+openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key -set_serial 0 -in certs/modelregistry-sample-grpc.domain.csr -out certs/modelregistry-sample-grpc.domain.crt -extfile certs/modelregistry-sample-grpc.domain.ext
+
+# create DB service cert and private key
+openssl req -out certs/model-registry-db.csr -newkey rsa:2048 -nodes -keyout certs/model-registry-db.key -subj "/CN=model-registry-db/O=modelregistry organization"
+openssl x509 -req -sha256 -days 365 -CA certs/domain.crt -CAkey certs/domain.key -set_serial 0 -in certs/model-registry-db.csr -out certs/model-registry-db.crt

--- a/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
+++ b/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
@@ -273,7 +273,7 @@ check_route_status() {
 
 # Function to source the rest api tests and run them.
 run_api_tests() {
-    ./test/scripts/rest.sh "-n istio-system" "$TOKEN" ../certs/domain.crt
+    ./test/scripts/istio-tls-rest.sh "-n istio-system" "$TOKEN" ../certs/domain.crt
 }
 
 # Run the deployment tests.

--- a/test/scripts/istio-tls-rest.sh
+++ b/test/scripts/istio-tls-rest.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 FLAG_WITH_NAMESPACE=$1
-MR_HOSTNAME="http://$(oc get route modelregistry-sample-http $FLAG_WITH_NAMESPACE --template='{{.spec.host}}')"
+TOKEN=$2
+CERT="certs/domain.crt"
+MR_HOSTNAME="https://$(oc get route odh-model-registries-modelregistry-sample-rest $FLAG_WITH_NAMESPACE --template='{{.spec.host}}')"
 
 # Function to send data and extract ID from response
 make_post_extract_id() {
 	local url="$1"
 	local data="$2"
-	local id=$(curl -s -X POST "$url" \
+	local id=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt "$url" \
 		-H 'accept: application/json' \
 		-H 'Content-Type: application/json' \
 		-d "$data" | jq -r '.id')

--- a/test/scripts/rest.sh
+++ b/test/scripts/rest.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 FLAG_WITH_NAMESPACE=$1
-MR_HOSTNAME="http://$(oc get route modelregistry-sample-http $FLAG_WITH_NAMESPACE --template='{{.spec.host}}')"
+TOKEN=$2
+CERT="certs/domain.crt"
+MR_HOSTNAME="https://$(oc get route odh-model-registries-modelregistry-sample-rest $FLAG_WITH_NAMESPACE --template='{{.spec.host}}')"
 
 # Function to send data and extract ID from response
 make_post_extract_id() {
 	local url="$1"
 	local data="$2"
-	local id=$(curl -s -X POST "$url" \
+	local id=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt "$url" \
 		-H 'accept: application/json' \
 		-H 'Content-Type: application/json' \
 		-d "$data" | jq -r '.id')


### PR DESCRIPTION
This PR will allow the deployment of model-registry-istio-tls in the PROW/openshift job.
The deployment files for this deployment are directly copied over from the model-registry-operator file.  Some the files will be unused at the moment but will likely be needed to give us the option to switch the PROW/openshift-ci job to use the any of the samples available in for PR checking.

### How was this tested
It was tested by running locally targeting an already deployed openshift cluster and was oc logged in.

> Deploying authorino-subscription from openshift-ci/resources/samples/authorino-subscription.yaml...
subscription.operators.coreos.com/authorino-operator created
✔ Success: Deployment of authorino-subscription succeeded.
Monitoring the installation of CRDs: authconfigs.authorino.kuadrant.io authconfigs.authorino.kuadrant.io authorinos.operator.authorino.kuadrant.io
Timeout set to 120s
✔ Success: All specified CRDs are installed.
Deploying service-mesh-subscription from openshift-ci/resources/samples/service-mesh-subscription.yaml...
subscription.operators.coreos.com/servicemeshoperator created
✔ Success: Deployment of service-mesh-subscription succeeded.
Monitoring the installation of CRDs: servicemeshcontrolplanes.maistra.io servicemeshmembers.maistra.io servicemeshmemberrolls.maistra.io
Timeout set to 120s
✔ Success: All specified CRDs are installed.
Deploying opendatahub-subscription from openshift-ci/resources/opendatahub-subscription.yaml...
subscription.operators.coreos.com/model-registry-test-source-subscription created
✔ Success: Deployment of opendatahub-subscription succeeded.
Monitoring the installation of CRDs: datascienceclusters.datasciencecluster.opendatahub.io dscinitializations.dscinitialization.opendatahub.io featuretrackers.features.opendatahub.io
Timeout set to 120s
✔ Success: All specified CRDs are installed.
Deploying model-registry-DSCInitialization from openshift-ci/resources/model-registry-DSCInitialization.yaml...
dscinitialization.dscinitialization.opendatahub.io/default-dsci created
✔ Success: Deployment of model-registry-DSCInitialization succeeded.
Deploying opendatahub-data-science-cluster from openshift-ci/resources/opendatahub-data-science-cluster.yaml...
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc created
✔ Success: Deployment of opendatahub-data-science-cluster succeeded.
Monitoring the installation of CRDs: acceleratorprofiles.dashboard.opendatahub.io datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io odhapplications.dashboard.opendatahub.io odhdashboardconfigs.opendatahub.io odhdocuments.dashboard.opendatahub.io
Timeout set to 120s
✔ Success: All specified CRDs are installed.
error: resource name may not be empty
! INFO:  Pod  is not running or does not have 2 containers ready
error: resource name may not be empty
! INFO:  Pod  is not running or does not have 2 containers ready
! INFO:  Pod model-registry-operator-controller-manager-8444ddd68-7vmts is not running or does not have 2 containers ready
! INFO:  Pod model-registry-operator-controller-manager-8444ddd68-7vmts is not running or does not have 2 containers ready
✔ Success: Pod model-registry-operator-controller-manager-8444ddd68-7vmts is running and 2 out of 2 containers are ready
apps.rk415.apicurio.integration-qe.com

> Certificate request self-signature ok
> subject=CN=model-registry-db, O=modelregistry organization
> modelregistry-sample-rest.domain.domain.key
> modelregistry-sample-rest.domain.domain.crt
> secret/modelregistry-sample-rest-credential created
> ✔ Success: Secret 'modelregistry-sample-rest-credential' created successfully in namespace 'istio-system'.
> modelregistry-sample-grpc.domain.domain.key
> modelregistry-sample-grpc.domain.domain.crt
> secret/modelregistry-sample-grpc-credential created
> ✔ Success: Secret 'modelregistry-sample-grpc-credential' created successfully in namespace 'istio-system'.
> model-registry-db.domain.key
> model-registry-db.domain.crt
> secret/model-registry-db-credential created
> ✔ Success: Secret 'model-registry-db-credential' created successfully in namespace 'odh-model-registries'.
> servicemeshmember.maistra.io/default created
> Getting ServiceMeshMember
> No resources found in istio-system namespace.
> Deploying mysql-tls from openshift-ci/resources/samples/istio/mysql-tls...
> configmap/modelregistry-sample-environment created
> secret/model-registry-db created
> service/model-registry-db created
> persistentvolumeclaim/model-registry-db created
> deployment.apps/model-registry-db created
> modelregistry.modelregistry.opendatahub.io/modelregistry-sample created
> ✔ Success: Deployment of mysql-tls succeeded.
> Monitoring the installation of CRDs: modelregistries.modelregistry.opendatahub.io
> Timeout set to 120s
> ✔ Success: All specified CRDs are installed.
> ✔ Success: Deployment model-registry-db is available
> ✔ Success: Deployment modelregistry-sample is available
> ! INFO:  Pod model-registry-db-59757bdd8-vjmjw is not running or does not have 1 containers ready
> ✔ Success: Pod model-registry-db-59757bdd8-vjmjw is running and 1 out of 1 containers are ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ! INFO:  Pod modelregistry-sample-866f6b7cb5-tstts is not running or does not have 3 containers ready
> ✔ Success: Pod modelregistry-sample-866f6b7cb5-tstts is running and 3 out of 3 containers are ready
> ✔ Success: Route 'odh-model-registries-modelregistry-sample-rest' exists in namespace 'istio-system'
> * Host modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com:443 was resolved.
> * IPv6: (none)
> * IPv4: 10.0.198.167
> *   Trying 10.0.198.167:443...
> * Connected to modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com (10.0.198.167) port 443
> * ALPN: curl offers h2,http/1.1
> } [5 bytes data]
> * TLSv1.3 (OUT), TLS handshake, Client hello (1):
> } [512 bytes data]
> *  CAfile: certs/domain.crt
> *  CApath: none
> { [5 bytes data]
> * TLSv1.3 (IN), TLS handshake, Server hello (2):
> { [122 bytes data]
> * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
> { [15 bytes data]
> * TLSv1.3 (IN), TLS handshake, Certificate (11):
> { [948 bytes data]
> * TLSv1.3 (IN), TLS handshake, CERT verify (15):
> { [264 bytes data]
> * TLSv1.3 (IN), TLS handshake, Finished (20):
> { [52 bytes data]
> * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
> } [1 bytes data]
> * TLSv1.3 (OUT), TLS handshake, Finished (20):
> } [52 bytes data]
> * SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / RSASSA-PSS
> * ALPN: server accepted h2
> * Server certificate:
> *  subject: CN=modelregistry-sample-rest; O=modelregistry organization
> *  start date: Jun 21 16:15:49 2024 GMT
> *  expire date: Jun 21 16:15:49 2025 GMT
> *  subjectAltName: host "modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com" matched cert's "modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com"
> *  issuer: O=modelregistry Inc.; CN=apps.rk415.apicurio.integration-qe.com
> *  SSL certificate verify ok.
> *   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
> *   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
> } [5 bytes data]
> * using HTTP/2
> * [HTTP/2] [1] OPENED stream for https://modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com/api/model_registry/v1alpha3/registered_models
> * [HTTP/2] [1] [:method: GET]
> * [HTTP/2] [1] [:scheme: https]
> * [HTTP/2] [1] [:authority: modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com]
> * [HTTP/2] [1] [:path: /api/model_registry/v1alpha3/registered_models]
> * [HTTP/2] [1] [user-agent: curl/8.5.0]
> * [HTTP/2] [1] [accept: */*]
> * [HTTP/2] [1] [authorization: Bearer sha256~TdtJQry5AlcnmLL4myvTQVxS0MxG6VT9ca923_l8sxA]
> } [5 bytes data]
> > GET /api/model_registry/v1alpha3/registered_models HTTP/2
> > Host: modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com
> > User-Agent: curl/8.5.0
> > Accept: */*
> > Authorization: Bearer sha256~TdtJQry5AlcnmLL4myvTQVxS0MxG6VT9ca923_l8sxA
> > 
> { [5 bytes data]
> * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
> { [265 bytes data]
> * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
> { [265 bytes data]
> * old SSL session ID is stale, removing
> { [5 bytes data]
> < HTTP/2 200 
> < content-type: application/json; charset=UTF-8
> < vary: Origin
> < date: Fri, 21 Jun 2024 16:17:09 GMT
> < content-length: 54
> < x-envoy-upstream-service-time: 38
> < server: istio-envoy
> < 
> { [54 bytes data]
> * Connection #0 to host modelregistry-sample-rest.apps.rk415.apicurio.integration-qe.com left intact
> ✔ Success: Route server is reachable. Status code: 200 OK
> Success: Registered Model ID: 1
> Success: Model Version ID: 2
> Success: Model Artifact ID: 1

### How to run the script and test the PR.
- git pull and checkout this PR
- from the root of the repo    ./openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
