### PR TITLE
TLS Cluster Fix

### DIFF
--- a/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
+++ b/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
@@ -251,7 +251,7 @@ check_route_status() {
         fi
 
         # Test if the route is live
-        local response=$(curl -v -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt -o /dev/null -s -w "%{http_code}" "https://modelregistry-sample-rest.$DOMAIN/api/model_registry/v1alpha3/registered_models")
+        local response=$(curl -k -v -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt -o /dev/null -s -w "%{http_code}" "https://modelregistry-sample-rest.$DOMAIN/api/model_registry/v1alpha3/registered_models")
 
         # Check if the response status code is 200 OK or 404 Not Found
         if [[ "$response" == "200" ]]; then
@@ -288,21 +288,21 @@ run_deployment_tests() {
 # Main function for orchestrating deployments
 main() {   
     set_up_env
-    deploy_and_wait "" $ATHORINO_SUBSCRIPTION 60
-    monitoring_crds_installation $AUTHORINO_CRDS 120
-    deploy_and_wait "" $SERVICE_MESH_SUBSCRIPTION 120
-    monitoring_crds_installation $SERVICE_MESH_CRDS 120
-    deploy_and_wait "" $OPENDATAHUB_SUBSCRIPTION 60
-    monitoring_crds_installation $OPENDATAHUB_CRDS 120
-    deploy_and_wait "" $DSC_INITIALIZATION_MANIFEST 20 
-    deploy_and_wait "" $DATA_SCIENCE_CLUSTER_MANIFEST 10 
-    monitoring_crds_installation $DATA_SCIENCE_CLUSTER_CRDS 120
-    check_pod_status "opendatahub" "-l component.opendatahub.io/name=model-registry-operator" 2 
-    create_certs
-    deploy_certs
-    add_namespace_to_istio_cp
-    deploy_and_wait "-n odh-model-registries" $MODEL_REGISTRY_SAMPLE_MANIFEST 20 "-k"
-    monitoring_crds_installation $MODEL_REGISTRY_CRDS 120
+    # deploy_and_wait "" $ATHORINO_SUBSCRIPTION 60
+    # monitoring_crds_installation $AUTHORINO_CRDS 120
+    # deploy_and_wait "" $SERVICE_MESH_SUBSCRIPTION 120
+    # monitoring_crds_installation $SERVICE_MESH_CRDS 120
+    # deploy_and_wait "" $OPENDATAHUB_SUBSCRIPTION 60
+    # monitoring_crds_installation $OPENDATAHUB_CRDS 120
+    # deploy_and_wait "" $DSC_INITIALIZATION_MANIFEST 20 
+    # deploy_and_wait "" $DATA_SCIENCE_CLUSTER_MANIFEST 10 
+    # monitoring_crds_installation $DATA_SCIENCE_CLUSTER_CRDS 120
+    # check_pod_status "opendatahub" "-l component.opendatahub.io/name=model-registry-operator" 2 
+    # create_certs
+    # deploy_certs
+    # add_namespace_to_istio_cp
+    # deploy_and_wait "-n odh-model-registries" $MODEL_REGISTRY_SAMPLE_MANIFEST 20 "-k"
+    # monitoring_crds_installation $MODEL_REGISTRY_CRDS 120
     run_deployment_tests
     run_api_tests "-n istio-system"
 }

--- a/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
+++ b/openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh
@@ -288,21 +288,21 @@ run_deployment_tests() {
 # Main function for orchestrating deployments
 main() {   
     set_up_env
-    # deploy_and_wait "" $ATHORINO_SUBSCRIPTION 60
-    # monitoring_crds_installation $AUTHORINO_CRDS 120
-    # deploy_and_wait "" $SERVICE_MESH_SUBSCRIPTION 120
-    # monitoring_crds_installation $SERVICE_MESH_CRDS 120
-    # deploy_and_wait "" $OPENDATAHUB_SUBSCRIPTION 60
-    # monitoring_crds_installation $OPENDATAHUB_CRDS 120
-    # deploy_and_wait "" $DSC_INITIALIZATION_MANIFEST 20 
-    # deploy_and_wait "" $DATA_SCIENCE_CLUSTER_MANIFEST 10 
-    # monitoring_crds_installation $DATA_SCIENCE_CLUSTER_CRDS 120
-    # check_pod_status "opendatahub" "-l component.opendatahub.io/name=model-registry-operator" 2 
-    # create_certs
-    # deploy_certs
-    # add_namespace_to_istio_cp
-    # deploy_and_wait "-n odh-model-registries" $MODEL_REGISTRY_SAMPLE_MANIFEST 20 "-k"
-    # monitoring_crds_installation $MODEL_REGISTRY_CRDS 120
+    deploy_and_wait "" $ATHORINO_SUBSCRIPTION 60
+    monitoring_crds_installation $AUTHORINO_CRDS 120
+    deploy_and_wait "" $SERVICE_MESH_SUBSCRIPTION 120
+    monitoring_crds_installation $SERVICE_MESH_CRDS 120
+    deploy_and_wait "" $OPENDATAHUB_SUBSCRIPTION 60
+    monitoring_crds_installation $OPENDATAHUB_CRDS 120
+    deploy_and_wait "" $DSC_INITIALIZATION_MANIFEST 20 
+    deploy_and_wait "" $DATA_SCIENCE_CLUSTER_MANIFEST 10 
+    monitoring_crds_installation $DATA_SCIENCE_CLUSTER_CRDS 120
+    check_pod_status "opendatahub" "-l component.opendatahub.io/name=model-registry-operator" 2 
+    create_certs
+    deploy_certs
+    add_namespace_to_istio_cp
+    deploy_and_wait "-n odh-model-registries" $MODEL_REGISTRY_SAMPLE_MANIFEST 20 "-k"
+    monitoring_crds_installation $MODEL_REGISTRY_CRDS 120
     run_deployment_tests
     run_api_tests "-n istio-system"
 }

--- a/test/scripts/istio-tls-rest.sh
+++ b/test/scripts/istio-tls-rest.sh
@@ -8,7 +8,7 @@ MR_HOSTNAME="https://$(oc get route odh-model-registries-modelregistry-sample-re
 make_post_extract_id() {
 	local url="$1"
 	local data="$2"
-	local id=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt "$url" \
+	local id=$(curl -k -s -X POST -H "Authorization: Bearer $TOKEN" --cacert certs/domain.crt "$url" \
 		-H 'accept: application/json' \
 		-H 'Content-Type: application/json' \
 		-d "$data" | jq -r '.id')


### PR DESCRIPTION
This commit changes the the curl commands in both scripts to use the -k flag as there were issues when working with certain openshift clusters.

## Description
A -k flag is needed to ensure the script will run against clusters that are not set up to accept self signed certs.

## How Has This Been Tested?
It has been tested locally. A pdf is attached with the output of the successful run.
To verify you will need an openshift cluster deployed and be oc logged in.
Git fetch and checkout this PR
From the root of the repo run this command: ./openshift-ci/scripts/oci-model-registry-istio-tls-deploy.sh 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
