### PR TITLE
Missed DB File Needing Update To Stop Test Creds Triggering Prodsec Scan

### DIFF
--- a/openshift-ci/resources/samples/samples/mysql/mysql-db.yaml
+++ b/openshift-ci/resources/samples/samples/mysql/mysql-db.yaml
@@ -120,7 +120,7 @@ items:
     name: model-registry-db
   stringData:
     database-name: "model_registry"
-    database-password: "TheBlurstOfTimes"
-    database-user: "mlmduser"
+    database-password: "TheBlurstOfTimes" # notsecret
+    database-user: "mlmduser" # notsecret
 kind: List
 metadata: {}


### PR DESCRIPTION
This commit will update the DB file to not trigger the prodsec security scan for test credentials. This file was missed on the initial PR to fix this issue.

## Description
Added a # notsecret tag to both the DB user and DB password lines in the file. This is recommended by prodsec to highlight test credentials.

## How Has This Been Tested?
Tested locally by running .gitleaks.toml file.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
