### PR TITLE
Removing value from istio.env

### DIFF
--- a/openshift-ci/resources/samples/istio/components/istio.env
+++ b/openshift-ci/resources/samples/istio/components/istio.env
@@ -1,5 +1,5 @@
 AUTH_PROVIDER=opendatahub-auth-provider
 ISTIO_INGRESS=ingressgateway
-DOMAIN=apps.rk415.apicurio.integration-qe.com
+DOMAIN=
 REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
 GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential


### PR DESCRIPTION
This commit will remove the value from the DOMAIN key in the istio.env file. It was mistakenly pushed with a value that varies. It no longer needs a value

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
This has been tested in the model-registry-operator via this [PR](https://github.com/opendatahub-io/model-registry-operator/pull/115)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
