### PR TITLE
ci: add test debugging step

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -89,4 +89,4 @@ jobs:
       - name: Check Pod Logs
         if: always()
         run: |
-          kubectl logs -l app=modelregistry-sample --all-containers -A --prefix
+          kubectl logs -l app=modelregistry-sample --all-containers --prefix

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           kubectl wait --for=condition=Available=true deployment/model-registry-db --timeout=5m
           kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
-          kubectl get deployments
-          kubectl get pods
+          kubectl get deployments -o wide
+          kubectl get pods -o wide
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -90,4 +90,4 @@ jobs:
       - name: Check Pod Logs
         if: always()
         run: |
-          kubectl logs -l app=modelregistry-sample --all-containers
+          kubectl logs -l app=modelregistry-sample --all-containers -A --prefix

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           kubectl wait --for=condition=Available=true deployment/model-registry-db --timeout=5m
           kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
+          kubectl get deployments
+          kubectl get pods
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -84,3 +86,8 @@ jobs:
           kubectl port-forward service/modelregistry-sample 8080:8080 &
           sleep 5
           python test/python/test_mr_conn.py http://localhost 8080
+
+      - name: Check Pod Logs
+        if: always()
+        run: |
+          kubectl logs -l app=modelregistry-sample --all-containers

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -86,7 +86,6 @@ jobs:
           kubectl port-forward service/modelregistry-sample 8080:8080 &
           sleep 5
           python test/python/test_mr_conn.py http://localhost 8080
-
       - name: Check Pod Logs
         if: always()
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
augment with debugging step


## How Has This Been Tested?
locally tested the command,
then making sure this PR execute as intended the GHA step

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the test deployment workflow to provide more detailed information about Kubernetes deployments and pods.
  * Added automatic retrieval of logs from relevant pods to aid in troubleshooting and visibility during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->