### PR TITLE
async-upload: change manifest default image

### DIFF
--- a/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
+++ b/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
@@ -37,7 +37,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: async-upload
-          image: kubeflow/model-registry-async-job:local
+          image: quay.io/opendatahub/model-registry-job-async-upload
           volumeMounts:
             - name: source-credentials
               readOnly: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
chore PR to update manifest sample in m/s ODH

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image for the async-upload job to use a remote registry image instead of a local development image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->