### PR TITLE
periodic sync upstream KF to midstream ODH

### DIFF
--- a/.github/workflows/async-upload-test.yml
+++ b/.github/workflows/async-upload-test.yml
@@ -17,11 +17,17 @@ on:
       - ".github/workflows/**"
 
 env:
+  # Async Job
+  JOB_IMG_REGISTRY: ghcr.io
+  JOB_IMG_ORG: kubeflow
+  JOB_IMG_NAME: model-registry/job/async-upload
+  JOB_IMG_VERSION: cicd
+  # MR Server
   IMG_REGISTRY: ghcr.io
   IMG_ORG: kubeflow
-  IMG_NAME: model-registry/job/async-upload
+  IMG_REPO: model-registry/server
+  IMG_VERSION: cicd
   PUSH_IMAGE: false
-  BRANCH: ${{ github.base_ref }}
 
 jobs:
   py-test:
@@ -69,8 +75,6 @@ jobs:
         run: |
           set -x
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-      - name: Start KinD cluster and load images
+      - name: Execute Sample Job E2E test
         run: |
-          make deploy-latest-mr # this also starts the KinD cluster
-          make dev-load-image
-      # TODO: to be continued here
+          make test-integration

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ __debug*
 model-registry
 metadata.sqlite.db
 
+# Temporary files for running the project
+.port-forwards.pid
+
 # Ignore go vendor and code coverage files
 vendor
 coverage.*

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,10 @@ IMG_REPO ?= model-registry/server
 # container image build path
 BUILD_PATH ?= .
 # container image
-ifdef IMG_REGISTRY
-    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}
+ifdef IMG
+	IMG := ${IMG}
+else ifdef IMG_REGISTRY
+    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}:${IMG_VERSION}
 else
     IMG := ${IMG_ORG}/${IMG_REPO}
 endif
@@ -336,7 +338,7 @@ endif
 # build docker image
 .PHONY: image/build
 image/build:
-	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG}:$(IMG_VERSION) $(ARGS)
+	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG} $(ARGS)
 
 # build docker image using buildx
 # PLATFORMS defines the target platforms for the model registry image be built to provide support to multiple

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILD_PATH ?= .
 ifdef IMG
 	IMG := ${IMG}
 else ifdef IMG_REGISTRY
-    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}:${IMG_VERSION}
+    IMG := ${IMG_REGISTRY}/${IMG_ORG}/${IMG_REPO}
 else
     IMG := ${IMG_ORG}/${IMG_REPO}
 endif
@@ -338,7 +338,7 @@ endif
 # build docker image
 .PHONY: image/build
 image/build:
-	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG} $(ARGS)
+	${DOCKER} build ${BUILD_PATH} -f ${DOCKERFILE} -t ${IMG}:$(IMG_VERSION) $(ARGS)
 
 # build docker image using buildx
 # PLATFORMS defines the target platforms for the model registry image be built to provide support to multiple

--- a/clients/python/.gitignore
+++ b/clients/python/.gitignore
@@ -6,5 +6,4 @@
 /.python-version
 __pycache__/
 venv/
-.port-forwards.pid
 .hypothesis/

--- a/jobs/async-upload/.dockerignore
+++ b/jobs/async-upload/.dockerignore
@@ -1,0 +1,1 @@
+.port-forwards.pid

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -8,7 +8,8 @@ CLUSTER_NAME ?= mr-e2e
 
 # MR Server Params
 IMG_VERSION ?= latest
-IMG ?= ghcr.io/kubeflow/model-registry/server:$(IMG_VERSION)
+# keep IMG consistent with root Makefile and ci/GHA:
+IMG ?= ghcr.io/kubeflow/model-registry/server
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
@@ -16,7 +17,8 @@ deploy-latest-mr:
 	$(if $(filter true,$(BUILD_IMAGE)),\
 		IMG_VERSION=${IMG_VERSION} IMG=${IMG} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)" && \
 	) \
-	LOCAL=1 IMG=${IMG} ./scripts/deploy_on_kind.sh
+	LOCAL=1 IMG=$(IMG):$(IMG_VERSION) ./scripts/deploy_on_kind.sh
+# TODO RHOAIENG-30453 align consistency ./scripts/deploy_on_kind.sh uses IMG with :tag, Vs, Makefile(s) and ci/GHA we use IMG without trailing :tag
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 & echo $$! >> .port-forwards.pid
 
 .PHONY: deploy-test-minio

--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -1,17 +1,22 @@
-IMG_VERSION ?= latest
-IMG_REGISTRY ?= ghcr.io
-IMG_ORG ?= kubeflow
-IMG_NAME ?= model-registry/job/async-upload
-IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(IMG_VERSION)
+JOB_IMG_VERSION ?= latest
+JOB_IMG_REGISTRY ?= ghcr.io
+JOB_IMG_ORG ?= kubeflow
+JOB_IMG_NAME ?= model-registry/job/async-upload
+JOB_IMG ?= $(JOB_IMG_REGISTRY)/$(JOB_IMG_ORG)/$(JOB_IMG_NAME):$(JOB_IMG_VERSION)
 BUILD_IMAGE ?= true # whether to build the MR server image
+CLUSTER_NAME ?= mr-e2e
+
+# MR Server Params
+IMG_VERSION ?= latest
+IMG ?= ghcr.io/kubeflow/model-registry/server:$(IMG_VERSION)
 
 .PHONY: deploy-latest-mr
 deploy-latest-mr:
 	cd ../../ && \
 	$(if $(filter true,$(BUILD_IMAGE)),\
-		IMG_VERSION=${IMG_VERSION} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)" && \
+		IMG_VERSION=${IMG_VERSION} IMG=${IMG} make image/build ARGS="--load$(if ${DEV_BUILD}, --target dev-build)" && \
 	) \
-	LOCAL=1 ./scripts/deploy_on_kind.sh
+	LOCAL=1 IMG=${IMG} ./scripts/deploy_on_kind.sh
 	kubectl port-forward -n kubeflow services/model-registry-service 8080:8080 & echo $$! >> .port-forwards.pid
 
 .PHONY: deploy-test-minio
@@ -28,8 +33,8 @@ deploy-local-registry:
 
 .PHONY: dev-load-image
 dev-load-image:
-	docker buildx build --load -t $(IMG) .
-	kind load docker-image $(IMG) -n mr-e2e
+	docker buildx build --load -t $(JOB_IMG) .
+	kind load docker-image $(JOB_IMG) -n $(CLUSTER_NAME)
 
 .PHONY: test
 test:
@@ -59,6 +64,20 @@ test-e2e-cleanup:
 		kill $$(cat .port-forwards.pid) || true; \
 		rm -f .port-forwards.pid; \
 	fi
+
+.PHONY: test-integration
+test-integration: deploy-latest-mr deploy-local-registry deploy-test-minio dev-load-image
+	@echo "Starting test-integration"
+	-$(MAKE) test-integration-run; STATUS=$$?
+	$(MAKE) test-e2e-cleanup
+	@exit $$STATUS
+
+.PHONY: test-integration-run
+test-integration-run:
+	@echo "Ensuring all extras are installed..."
+	poetry install --all-extras --with integration
+	@echo "Running integration tests..."
+	CONTAINER_IMAGE_URI=$(JOB_IMG) poetry run pytest --integration tests/integration/ -vs
 
 .PHONY: install
 install:

--- a/jobs/async-upload/job/config.py
+++ b/jobs/async-upload/job/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import base64
 import json
 import logging
 import configargparse as cap
@@ -7,6 +6,7 @@ from typing import Any, Dict, Mapping
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
 
 def _parser() -> cap.ArgumentParser:
     """Parse command line arguments and config files"""
@@ -19,7 +19,8 @@ def _parser() -> cap.ArgumentParser:
     # --- source ---
     # s3
     # TODO: We should be able to infer the type from the credentials provided, therefore no default needed
-    p.add_argument("--source-type", choices=["s3", "oci"], default="s3")
+    p.add_argument("--source-type", choices=["s3", "oci", "uri"], default="s3")
+    p.add_argument("--source-uri")
     p.add_argument("--source-aws-bucket")
     p.add_argument("--source-aws-key")
     p.add_argument("--source-aws-region")
@@ -50,7 +51,7 @@ def _parser() -> cap.ArgumentParser:
     p.add_argument("--destination-oci-base-image", default="busybox:latest")
     # The `type` converter is needed here to support env-based booleans
     # See: https://github.com/bw2/ConfigArgParse/tree/master?tab=readme-ov-file#special-values
-    p.add_argument("--destination-oci-enable-tls-verify", default=True, type=str2bool) 
+    p.add_argument("--destination-oci-enable-tls-verify", default=True, type=str2bool)
 
     # --- model-registry model data ---
     p.add_argument("--model-id")
@@ -190,6 +191,11 @@ def _validate_s3_config(cfg: Dict[str, Any]) -> None:
         raise ValueError("S3 key must be set")
 
 
+def _validate_uri_config(cfg: Dict[str, Any]) -> None:
+    if not ("uri" in cfg and isinstance(cfg["uri"], str)):
+        raise ValueError("uri must be set to a string")
+
+
 def _validate_model_config(cfg: Dict[str, Any]) -> None:
     """Validates the model config is valid"""
     if cfg["id"] is None or cfg["version_id"] is None or cfg["artifact_id"] is None:
@@ -208,6 +214,8 @@ def _validate_store(cfg: Dict[str, Any]) -> None:
         _validate_s3_config(cfg)
     elif cfg["type"] == "oci":
         _validate_oci_config(cfg)
+    elif cfg["type"] == "uri":
+        _validate_uri_config(cfg)
     else:
         raise ValueError("Source type must be set")
 
@@ -224,6 +232,7 @@ def _validate_config(cfg: Dict[str, Any]) -> None:
 
     # Ensure the registry is valid
     _validate_registry_config(cfg["registry"])
+
 
 def str2bool(x):
     """Convert a config string to boolean. This is needed because configargparse doesn't support boolean optional action as env vars"""
@@ -331,6 +340,7 @@ def get_config(argv: list[str] | None = None) -> Dict[str, Any]:
 
     # TODO: Maybe clean this up, its a little manual
     # Override with command-line arguments if provided. configargparse will prioritize CLI > ENV
+    cfg["source"]["uri"] = args.source_uri
     if args.source_aws_bucket:
         cfg["source"]["s3"]["bucket"] = args.source_aws_bucket
     if args.source_aws_key:
@@ -388,29 +398,30 @@ def _sanitize_config_for_logging(cfg: Dict[str, Any]) -> Dict[str, Any]:
     Create a sanitized copy of the config for logging purposes, masking sensitive values.
     """
     import copy
+
     sanitized = copy.deepcopy(cfg)
-    
+
     # Mask sensitive S3 credentials
     if sanitized["source"]["s3"]["secret_access_key"]:
         sanitized["source"]["s3"]["secret_access_key"] = "***"
     if sanitized["source"]["s3"]["access_key_id"]:
         sanitized["source"]["s3"]["access_key_id"] = "***"
-    
+
     if sanitized["destination"]["s3"]["secret_access_key"]:
         sanitized["destination"]["s3"]["secret_access_key"] = "***"
     if sanitized["destination"]["s3"]["access_key_id"]:
         sanitized["destination"]["s3"]["access_key_id"] = "***"
-    
+
     # Mask sensitive OCI credentials
     if sanitized["source"]["oci"]["password"]:
         sanitized["source"]["oci"]["password"] = "***"
     if sanitized["destination"]["oci"]["password"]:
         sanitized["destination"]["oci"]["password"] = "***"
-    
+
     # Mask sensitive registry credentials
     if sanitized["registry"]["user_token"]:
         sanitized["registry"]["user_token"] = "***"
     if sanitized["registry"]["custom_ca"]:
         sanitized["registry"]["custom_ca"] = "***"
-    
+
     return sanitized

--- a/jobs/async-upload/job/download.py
+++ b/jobs/async-upload/job/download.py
@@ -7,6 +7,8 @@ from model_registry.utils import _connect_to_s3
 
 logger = logging.getLogger(__name__)
 
+HF_URI_PREFIX = "hf://"
+
 
 def download_from_s3(client: ModelRegistry, config: Dict[str, Any]):
     logger.debug("🔍 Downloading model from S3...")
@@ -42,12 +44,49 @@ def download_from_s3(client: ModelRegistry, config: Dict[str, Any]):
     logger.debug("✅ Model files downloaded from S3")
 
 
+def download_from_hf(uri: str, dest_dir: str) -> str:
+    """
+    adapted from kserve:
+    https://github.com/kserve/kserve/blob/4edbb36c520c2e880842229bfc56b7f11d766822/python/storage/kserve_storage/kserve_storage.py#L292-L322
+    """
+    from huggingface_hub import snapshot_download
+
+    if not uri.startswith(HF_URI_PREFIX):
+        raise ValueError(f"Expected URI beginning with {HF_URI_PREFIX}")
+
+    components = uri[len(HF_URI_PREFIX) :].split("/")
+    if len(components) != 2:
+        raise ValueError(
+            "URI must contain exactly one '/' separating the repo and model name"
+        )
+
+    repo, model_id = components
+    if not repo:
+        raise ValueError("Repository name cannot be empty")
+
+    model_name, _, hash_value = model_id.partition(":")
+    if not model_name:
+        raise ValueError("Model name cannot be empty")
+
+    revision = hash_value if hash_value else None
+    return snapshot_download(
+        repo_id=f"{repo}/{model_name}", revision=revision, local_dir=dest_dir
+    )
+
+
 def perform_download(client: ModelRegistry, config: Dict[str, Any]):
     logger.info("📥 Downloading model from source...")
     # Download the model from the defined source
-    if config["source"]["type"] == "s3":
+    source_type = config["source"]["type"]
+    if source_type == "s3":
         download_from_s3(client, config)
-    elif config["source"]["type"] == "oci":
+    elif source_type == "uri":
+        uri = config["source"]["uri"]
+        if uri.startswith(HF_URI_PREFIX):
+            download_from_hf(config["source"]["uri"], config["storage"]["path"])
+        else:
+            raise ValueError(f"Unsupported URI format: {uri}")
+    elif source_type == "oci":
         # TODO: Implement the OCI download logic here
         raise ValueError("OCI source is not supported yet")
     else:

--- a/jobs/async-upload/poetry.lock
+++ b/jobs/async-upload/poetry.lock
@@ -241,6 +241,132 @@ urllib3 = [
 crt = ["awscrt (==0.23.8)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
+name = "certifi"
+version = "2025.7.14"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2"},
+    {file = "certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"},
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-win32.whl", hash = "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a"},
+    {file = "charset_normalizer-3.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-win32.whl", hash = "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a"},
+    {file = "charset_normalizer-3.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c"},
+    {file = "charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7"},
+    {file = "charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cad5f45b3146325bb38d6855642f6fd609c3f7cad4dbaf75549bf3b904d3184"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2680962a4848b3c4f155dc2ee64505a9c57186d0d56b43123b17ca3de18f0fa"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:36b31da18b8890a76ec181c3cf44326bf2c48e36d393ca1b72b3f484113ea344"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4074c5a429281bf056ddd4c5d3b740ebca4d43ffffe2ef4bf4d2d05114299da"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9e36a97bee9b86ef9a1cf7bb96747eb7a15c2f22bdb5b516434b00f2a599f02"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:1b1bde144d98e446b056ef98e59c256e9294f6b74d7af6846bf5ffdafd687a7d"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:915f3849a011c1f593ab99092f3cecfcb4d65d8feb4a64cf1bf2d22074dc0ec4"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:25a23ea5c7edc53e0f29bae2c44fcb5a1aa10591aae107f2a2b2583a9c5cbc64"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:770cab594ecf99ae64c236bc9ee3439c3f46be49796e265ce0cc8bc17b10294f"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-win32.whl", hash = "sha256:6a0289e4589e8bdfef02a80478f1dfcb14f0ab696b5a00e1f4b8a14a307a3c58"},
+    {file = "charset_normalizer-3.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6fc1f5b51fa4cecaa18f2bd7a003f3dd039dd615cd69a2afd6d3b19aed6775f2"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-win32.whl", hash = "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7"},
+    {file = "charset_normalizer-3.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-win32.whl", hash = "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471"},
+    {file = "charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e"},
+    {file = "charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0"},
+    {file = "charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 description = "Composable command line interface toolkit"
@@ -300,6 +426,18 @@ files = [
 [package.extras]
 test = ["PyYAML", "mock", "pytest"]
 yaml = ["PyYAML"]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+description = "Module for converting between datetime.timedelta and Go's Duration strings."
+optional = false
+python-versions = "*"
+groups = ["integration"]
+files = [
+    {file = "durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286"},
+    {file = "durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba"},
+]
 
 [[package]]
 name = "eval-type-backport"
@@ -450,12 +588,39 @@ files = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.40.3"
+description = "Google Authentication Library"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca"},
+    {file = "google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77"},
+]
+
+[package.dependencies]
+cachetools = ">=2.0.0,<6.0"
+pyasn1-modules = ">=0.2.1"
+rsa = ">=3.1.4,<5"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
+enterprise-cert = ["cryptography", "pyopenssl"]
+pyjwt = ["cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "flask", "freezegun", "grpcio", "mock", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integration"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -487,6 +652,34 @@ files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
+
+[[package]]
+name = "kubernetes"
+version = "33.1.0"
+description = "Kubernetes python client"
+optional = false
+python-versions = ">=3.6"
+groups = ["integration"]
+files = [
+    {file = "kubernetes-33.1.0-py2.py3-none-any.whl", hash = "sha256:544de42b24b64287f7e0aa9513c93cb503f7f40eea39b20f66810011a86eabc5"},
+    {file = "kubernetes-33.1.0.tar.gz", hash = "sha256:f64d829843a54c251061a8e7a14523b521f2dc5c896cf6d65ccf348648a88993"},
+]
+
+[package.dependencies]
+certifi = ">=14.05.14"
+durationpy = ">=0.7"
+google-auth = ">=1.0.1"
+oauthlib = ">=3.2.2"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=5.4.1"
+requests = "*"
+requests-oauthlib = "*"
+six = ">=1.9.0"
+urllib3 = ">=1.24.2"
+websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
+
+[package.extras]
+adal = ["adal (>=1.0.2)"]
 
 [[package]]
 name = "model-registry"
@@ -646,6 +839,23 @@ files = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
+
+[[package]]
 name = "olot"
 version = "0.1.8"
 description = "oci layers on top"
@@ -796,6 +1006,33 @@ files = [
     {file = "propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f"},
     {file = "propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168"},
 ]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
+    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
 name = "pydantic"
@@ -960,7 +1197,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "integration"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -968,6 +1205,125 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
+name = "requests"
+version = "2.32.4"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset_normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = false
+python-versions = ">=3.4"
+groups = ["integration"]
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+description = "Pure-Python RSA implementation"
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["integration"]
+files = [
+    {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
+    {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3transfer"
@@ -993,7 +1349,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "integration"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -1076,7 +1432,7 @@ version = "1.26.20"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-groups = ["main"]
+groups = ["main", "integration"]
 markers = "python_version < \"3.10\""
 files = [
     {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
@@ -1094,7 +1450,7 @@ version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integration"]
 markers = "python_version >= \"3.10\""
 files = [
     {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
@@ -1106,6 +1462,23 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+description = "WebSocket client for Python with low level API options"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
+    {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx-rtd-theme (>=1.1.0)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
 
 [[package]]
 name = "yarl"
@@ -1229,4 +1602,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "aaabbbecd75df9217a2902a644a365b62138400503af4908f3ef9937f5dcf77b"
+content-hash = "a4409587fcc3b0ba94d2789c16099a199166a61ddd3ba63f3316ad4bdb25ef3f"

--- a/jobs/async-upload/pyproject.toml
+++ b/jobs/async-upload/pyproject.toml
@@ -15,6 +15,10 @@ model-registry = { version = ">=0.2.19,<0.3.0", extras = ["boto3", "olot"] }
 pytest = ">=8.3.5,<9.0.0"
 aiohttp = "^3.12.14"
 
+[tool.poetry.group.integration.dependencies]
+kubernetes = "^33.0.0"
+requests = "^2.31.0"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
@@ -23,7 +27,8 @@ build-backend = "poetry.core.masonry.api"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 markers = [
-    "e2e: marks tests as end-to-end tests"
+    "e2e: marks tests as end-to-end tests",
+    "integration: marks tests as integration tests"
 ]
 
 [tool.poetry.scripts]

--- a/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
+++ b/jobs/async-upload/samples/sample_job_s3_to_oci.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: my-s3-credentials
+  namespace: default
 stringData:
   AWS_ACCESS_KEY_ID: minioadmin
   AWS_SECRET_ACCESS_KEY: minioadmin
@@ -14,6 +15,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: my-oci-credentials
+  namespace: default
 type: kubernetes.io/dockerconfigjson
 stringData:
   .dockerconfigjson: '{"auths": {"distribution-registry-test-service.default.svc.cluster.local:5001": {"auth": "","email": "user@example.com"}}}'
@@ -24,6 +26,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: my-async-upload-job
+  namespace: default
   labels:
     app.kubernetes.io/name: model-registry-async-job
     app.kubernetes.io/component: async-job

--- a/jobs/async-upload/tests/conftest.py
+++ b/jobs/async-upload/tests/conftest.py
@@ -8,14 +8,29 @@ def pytest_collection_modifyitems(config, items):
         skip_e2e = pytest.mark.skip(
             reason="this is an end-to-end test, requires explicit opt-in --e2e option to run."
         )
+        skip_integration = pytest.mark.skip(
+            reason="this is an integration test, requires explicit opt-in --integration option to run."
+        )
         skip_not_e2e = pytest.mark.skip(
             reason="skipping non-e2e tests; opt-out of --e2e -like options to run."
         )
+        skip_not_integration = pytest.mark.skip(
+            reason="skipping non-integration tests; opt-out of --integration -like options to run."
+        )
+        
+        e2e_option = config.getoption("--e2e")
+        integration_option = config.getoption("--integration")
+        
         if "e2e" in item.keywords:
-            if not config.getoption("--e2e"):
+            if not e2e_option:
                 item.add_marker(skip_e2e)
-        elif config.getoption("--e2e"):
+        elif "integration" in item.keywords:
+            if not integration_option:
+                item.add_marker(skip_integration)
+        elif e2e_option:
             item.add_marker(skip_not_e2e)
+        elif integration_option:
+            item.add_marker(skip_not_integration)
 
 
 def pytest_addoption(parser):
@@ -24,4 +39,10 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="opt-in to run tests marked with e2e",
+    )
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="opt-in to run tests marked with integration",
     )

--- a/jobs/async-upload/tests/integration/README.md
+++ b/jobs/async-upload/tests/integration/README.md
@@ -1,0 +1,83 @@
+# Integration Tests for Async-Upload Job
+
+This directory contains integration tests for the async-upload job functionality, specifically testing the complete workflow from model creation through job execution and validation.
+
+## Installation
+
+To run the integration tests, you need to install the integration test dependencies:
+
+```bash
+# Install all dependencies including integration test dependencies
+poetry install --with integration
+
+# Or install just the integration group
+poetry install --only integration
+
+# No external CLI tools required - everything is pure Python!
+```
+
+## Dependencies Added
+
+The integration tests require the following additional dependencies:
+
+### Main Dependencies (added to `[tool.poetry.dependencies]`)
+
+- **`requests`**: For HTTP calls (downloading models, uploading to MinIO)
+- **`pyyaml`**: For YAML processing (kustomization files)
+
+### Integration Test Dependencies (added to `[tool.poetry.group.integration.dependencies]`)
+
+- **`kubernetes`**: Official Python client for Kubernetes API operations
+
+### Pure Python Approach
+
+The integration tests use a pure Python approach without external dependencies:
+
+- **No subprocess calls**: All operations use Python libraries
+- **No kustomize CLI**: YAML patching is done using pure Python dict operations
+- **No shell commands**: Everything is handled through Python APIs
+
+## Running the Tests
+
+```bash
+# Run integration tests only
+poetry run pytest --integration tests/integration/ -v
+
+# Run with environment variables
+MR_HOST_URL=http://my-registry:8080 poetry run pytest --integration tests/integration/ -v
+
+# Run all tests including integration
+poetry run pytest --integration tests/ -v
+```
+
+## Test Requirements
+
+The integration tests require:
+
+1. **Model Registry service** running (default: `http://localhost:8080`)
+2. **MinIO service** running (default: `http://localhost:9000`)
+3. **Kubernetes cluster** with kubectl configured
+4. **OCI registry** for job artifact storage
+
+## Environment Variables
+
+- `MR_HOST_URL`: Model Registry URL (default: `http://localhost:8080`)
+- `CONTAINER_IMAGE_URI`: Container image for the async-upload job (default: `ghcr.io/kubeflow/model-registry/job/async-upload:latest`)
+
+## What the Tests Do
+
+The integration tests validate the complete async-upload job workflow:
+
+1. **Model Registry Setup**: Creates RegisteredModel, ModelVersion, and placeholder ModelArtifact
+2. **File Operations**: Downloads ONNX model and uploads to MinIO using pure Python
+3. **Kubernetes Job**: Creates and applies job using pure Python YAML patching (no kustomize CLI)
+4. **Validation**: Verifies job completion and artifact state updates using kubernetes client
+
+## Debugging Failed Tests
+
+If tests fail, check:
+
+1. **Services are running**: Model Registry, MinIO, Kubernetes cluster
+2. **Connectivity**: Can reach all required services
+3. **Permissions**: Kubernetes permissions for job creation
+4. **Logs**: Integration test captures and displays pod logs on failure

--- a/jobs/async-upload/tests/integration/__init__.py
+++ b/jobs/async-upload/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for async-upload job functionality.""" 

--- a/jobs/async-upload/tests/integration/test_integration_async_upload.py
+++ b/jobs/async-upload/tests/integration/test_integration_async_upload.py
@@ -1,0 +1,365 @@
+"""Integration tests for async-upload job functionality."""
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+import requests
+import yaml
+
+# Import model registry client for API operations
+try:
+    from model_registry import ModelRegistry
+    from model_registry.types import ArtifactState
+except ImportError:
+    pytest.skip("model-registry client not available", allow_module_level=True)
+
+
+@pytest.fixture(scope="session")
+def k8s_client():
+    """Load Kubernetes config and return client."""
+    kubernetes = pytest.importorskip("kubernetes")
+    try:
+        kubernetes.config.load_kube_config()
+    except Exception:
+        # If kubeconfig loading fails, try in-cluster config
+        kubernetes.config.load_incluster_config()
+    return kubernetes.client.ApiClient()
+
+
+@pytest.fixture(scope="session")
+def k8s_batch_client():
+    """Return Kubernetes Batch API client."""
+    kubernetes = pytest.importorskip("kubernetes")
+    try:
+        kubernetes.config.load_kube_config()
+    except Exception:
+        kubernetes.config.load_incluster_config()
+    return kubernetes.client.BatchV1Api()
+
+
+@pytest.fixture(scope="session")
+def k8s_core_client():
+    """Return Kubernetes Core API client."""
+    kubernetes = pytest.importorskip("kubernetes")
+    try:
+        kubernetes.config.load_kube_config()
+    except Exception:
+        kubernetes.config.load_incluster_config()
+    return kubernetes.client.CoreV1Api()
+
+
+@pytest.fixture(scope="session")
+def model_registry_client():
+    """Create model registry client for integration tests."""
+    mr_host_url = os.environ.get("MR_HOST_URL", "http://localhost:8080")
+    # Parse URL to extract host and port
+    from urllib.parse import urlparse
+    parsed = urlparse(mr_host_url)
+    host = f"{parsed.scheme}://{parsed.hostname}"
+    port = parsed.port or (443 if parsed.scheme == "https" else 8080)
+    
+    return ModelRegistry(host, port, author="integration-test", is_secure=False)
+
+
+def apply_job_with_strategic_merge(
+    rm_id: str,
+    mv_id: str, 
+    ma_id: str,
+    job_name: str,
+    container_image_uri: str,
+    k8s_client
+) -> str:
+    """Apply job using Kustomize strategic merge patches."""
+    import subprocess
+    import tempfile
+    import time
+    
+    # Strategic merge patch template - only patch the image and env vars, keep original job name
+    patch_template = f"""apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-async-upload-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: async-upload
+        image: {container_image_uri}
+        env:
+        - name: MODEL_SYNC_MODEL_ID
+          value: "{rm_id}"
+        - name: MODEL_SYNC_MODEL_VERSION_ID
+          value: "{mv_id}"
+        - name: MODEL_SYNC_MODEL_ARTIFACT_ID
+          value: "{ma_id}"
+"""
+
+    # Get the path to the sample job file
+    base_job_path = Path(__file__).parent.parent.parent / "samples" / "sample_job_s3_to_oci.yaml"
+    
+    # Kustomization template using relative path and modern patches syntax
+    kustomization_template = """apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sample_job_s3_to_oci.yaml
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Job
+    name: my-async-upload-job
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        
+        # Copy the base job file into temp directory
+        import shutil
+        base_job_copy = temp_path / "sample_job_s3_to_oci.yaml"
+        shutil.copy2(base_job_path, base_job_copy)
+        
+        # Write the patch file
+        patch_file = temp_path / "patch.yaml"
+        with open(patch_file, "w") as f:
+            f.write(patch_template)
+        
+        # Write the kustomization file
+        kustomize_file = temp_path / "kustomization.yaml"  
+        with open(kustomize_file, "w") as f:
+            f.write(kustomization_template)
+        
+        # Delete existing job if it exists (Jobs are immutable)
+        delete_result = subprocess.run(
+            ["kubectl", "delete", "job", "my-async-upload-job", "-n", "default", "--ignore-not-found=true"],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+        if delete_result.returncode == 0:
+            print(f"Deleted existing job: {delete_result.stdout.strip()}")
+            # Wait a moment for deletion to complete
+            time.sleep(3)
+        
+        # Apply resources using kubectl apply -k
+        result = subprocess.run(
+            ["kubectl", "apply", "-k", "."],
+            capture_output=True,
+            text=True,
+            cwd=temp_path,
+            check=False
+        )
+        
+        if result.returncode != 0:
+            raise Exception(f"kubectl apply failed: {result.stderr}")
+        
+        # Return the original job name since we're not changing it
+        return "my-async-upload-job"
+
+
+
+
+def wait_for_job_completion(
+    job_name: str,
+    namespace: str,
+    batch_client,
+    timeout_seconds: int = 600
+) -> bool:
+    """Wait for job completion and return success status."""
+    start_time = time.time()
+    
+    while time.time() - start_time < timeout_seconds:
+        try:
+            job = batch_client.read_namespaced_job(name=job_name, namespace=namespace)
+            
+            # Check if job is complete
+            if job.status.conditions:
+                for condition in job.status.conditions:
+                    if condition.type == "Complete" and condition.status == "True":
+                        return True
+                    elif condition.type == "Failed" and condition.status == "True":
+                        return False
+            
+            time.sleep(10)  # Wait 10 seconds before checking again
+            
+        except Exception as e:
+            if hasattr(e, 'status') and getattr(e, 'status', None) == 404:
+                # Job doesn't exist yet
+                time.sleep(5)
+                continue
+            else:
+                raise
+    
+    return False
+
+
+def upload_to_minio(file_path: str, bucket: str, key: str) -> None:
+    """Upload file to MinIO using boto3."""
+    import boto3
+    from botocore.exceptions import ClientError
+    
+    # MinIO credentials (hardcoded for this test)
+    access_key = "minioadmin"
+    secret_key = "minioadmin"
+    
+    # Create S3 client configured for MinIO
+    s3_client = boto3.client(
+        's3',
+        endpoint_url='http://localhost:9000',
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name='us-east-1'  # MinIO doesn't care about region but boto3 requires it
+    )
+    
+    try:
+        # Upload the file
+        s3_client.upload_file(file_path, bucket, key)
+    except ClientError as e:
+        raise Exception(f"Failed to upload to MinIO: {e}")
+
+
+@pytest.mark.integration
+def test_async_upload_integration(
+    k8s_client,
+    k8s_batch_client,
+    k8s_core_client,
+    model_registry_client: ModelRegistry
+):
+    """Test the complete async-upload job integration.
+    
+    This test:
+    1. Creates a RegisteredModel, ModelVersion, and placeholder ModelArtifact
+    2. Downloads and uploads an ONNX model to MinIO
+    3. Creates and applies a Kubernetes job using kustomize
+    4. Waits for job completion
+    5. Validates the final artifact state
+    """
+    
+    # Configuration
+    mr_host_url = os.environ.get("MR_HOST_URL", "http://localhost:8080")
+    container_image_uri = os.environ.get(
+        "CONTAINER_IMAGE_URI",
+        "ghcr.io/kubeflow/model-registry/job/async-upload:latest"
+    )
+    job_name = f"test-async-upload-job-{uuid.uuid4().hex[:8]}"
+    namespace = "default"
+    
+    # Step 1: Create RegisteredModel
+    print("Creating RegisteredModel...")
+    model_name = f"test-model-{uuid.uuid4().hex[:8]}"
+    rm = model_registry_client.register_model(
+        name=model_name,
+        uri="PLACEHOLDER",  # Will be updated by the job
+        version="v1.0.0",
+        model_format_name="onnx",
+        model_format_version="1.0",
+        description="Test model for async upload"
+    )
+    assert rm.id
+    print(f"  Created RegisteredModel with ID: {rm.id}")
+    
+    # Get the created model version and artifact
+    mv = model_registry_client.get_model_version(model_name, "v1.0.0")
+    assert mv and mv.id
+    print(f"  Created ModelVersion with ID: {mv.id}")
+    
+    ma = model_registry_client.get_model_artifact(model_name, "v1.0.0")
+    assert ma and ma.id
+    print(f"  Created ModelArtifact with ID: {ma.id}")
+    
+    # Verify initial state
+    assert ma.uri == "PLACEHOLDER"
+    assert ma.state == ArtifactState.UNKNOWN
+    
+    # Step 2: Download and upload ONNX model
+    print("Downloading ONNX model...")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        model_file = Path(temp_dir) / "mnist-8.onnx"
+        
+        # Download the model
+        response = requests.get(
+            "https://github.com/onnx/models/raw/refs/heads/main/validated/vision/classification/mnist/model/mnist-8.onnx"
+        )
+        response.raise_for_status()
+        
+        with open(model_file, "wb") as f:
+            f.write(response.content)
+        
+        print("Uploading to MinIO...")
+        bucket = "default"
+        key = f"my-model/mnist-8.onnx"
+        upload_to_minio(str(model_file), bucket, key)
+        
+        # Step 3: Apply the job with patches
+        print("Applying resources...")
+        actual_job_name = apply_job_with_strategic_merge(
+            rm_id=rm.id,
+            mv_id=mv.id,
+            ma_id=ma.id,
+            job_name=job_name,
+            container_image_uri=container_image_uri,
+            k8s_client=k8s_client
+        )
+        
+        # Use the actual job name returned from kustomize
+        if actual_job_name:
+            job_name = actual_job_name
+        
+        print(f"Waiting for job completion: {job_name}")
+        success = wait_for_job_completion(job_name, namespace, k8s_batch_client, timeout_seconds=600)
+        
+        if not success:
+            # Get job logs for debugging
+            try:
+                pods = k8s_core_client.list_namespaced_pod(
+                    namespace=namespace,
+                    label_selector=f"job-name={job_name}"
+                )
+                for pod in pods.items:
+                    logs = k8s_core_client.read_namespaced_pod_log(
+                        name=pod.metadata.name,
+                        namespace=namespace
+                    )
+                    print(f"Pod {pod.metadata.name} logs:\n{logs}")
+            except Exception as e:
+                print(f"Could not get pod logs: {e}")
+            
+            pytest.fail("Job did not complete successfully")
+        
+        print("Job completed successfully!")
+        
+        # Step 7: Validate the final artifact state
+        print("Validating final artifact state...")
+        
+        # Wait a bit for the artifact to be updated
+        time.sleep(2)
+        
+        # Fetch the updated artifact
+        updated_ma = model_registry_client.get_model_artifact(model_name, "v1.0.0")
+        assert updated_ma
+        
+        # Validate the artifact was updated correctly
+        assert updated_ma.uri != "PLACEHOLDER", f"URI was not updated: {updated_ma.uri}"
+        assert updated_ma.state == ArtifactState.LIVE, f"State was not updated to LIVE: {updated_ma.state}"
+        
+        print(f"✅ Artifact URI updated to: {updated_ma.uri}")
+        print(f"✅ Artifact state updated to: {updated_ma.state}")
+        
+        # Clean up the job
+        try:
+            import subprocess
+            subprocess.run(
+                ["kubectl", "delete", "job", job_name, "-n", namespace],
+                capture_output=True,
+                check=False
+            )
+        except Exception:
+            pass  # Ignore cleanup errors
+        
+        print("Integration test completed successfully!") 

--- a/manifests/kustomize/base/model-registry-deployment.yaml
+++ b/manifests/kustomize/base/model-registry-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             timeoutSeconds: 2
           readinessProbe:
             initialDelaySeconds: 10
-            periodSeconds: 60
+            periodSeconds: 20
             httpGet:
               path: /readyz/isDirty
               port: http-api


### PR DESCRIPTION
- keep https://github.com/kubeflow/model-registry/pull/1365
- keep https://github.com/kubeflow/model-registry/pull/1370
- keep https://github.com/kubeflow/model-registry/pull/1326
- keep https://github.com/kubeflow/model-registry/pull/1372
- resolving conflict with f9917de108fe22900325d6507ecdcf76f630daa4

labels are applied

/ok-to-test
/lgtm
/approve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading models from Hugging Face repositories via URI in the async-upload job.
  * Introduced integration tests for the async-upload job, including documentation and test infrastructure.
  * Added new command-line argument to specify source URI for model downloads.

* **Bug Fixes**
  * Explicitly set namespaces for Kubernetes resources in sample job manifests to avoid deployment issues.

* **Chores**
  * Improved .gitignore and .dockerignore handling for temporary files.
  * Updated workflow and Makefile logic for better image variable management and integration test execution.
  * Refined readiness probe frequency for model registry deployment.

* **Documentation**
  * Added comprehensive integration test README for async-upload job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->