### PR TITLE
[WIP] Get model registries working for OpenShift

### DIFF
--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -40,9 +40,6 @@ func main() {
 	flag.StringVar(&cfg.AuthTokenHeader, "auth-token-header", getEnvAsString("AUTH_TOKEN_HEADER", config.DefaultAuthTokenHeader), "Header used to extract the token (e.g., Authorization)")
 	flag.StringVar(&cfg.AuthTokenPrefix, "auth-token-prefix", getEnvAsString("AUTH_TOKEN_PREFIX", config.DefaultAuthTokenPrefix), "Prefix used in the token header (e.g., 'Bearer ')")
 
-	// TLS configuration flags
-	flag.BoolVar(&cfg.InsecureSkipVerify, "insecure-skip-verify", getEnvAsBool("INSECURE_SKIP_VERIFY", false), "Skip TLS certificate verification (useful for development, default: false)")
-
 	// Deprecated flags - kept for backward compatibility
 	flag.BoolVar(&cfg.StandaloneMode, "standalone-mode", false, "DEPRECATED: Use -deployment-mode=standalone instead")
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")
@@ -65,8 +62,8 @@ func main() {
 	}))
 
 	//validate auth method
-	if cfg.AuthMethod != config.AuthMethodInternal && cfg.AuthMethod != config.AuthMethodUser {
-		logger.Error("invalid auth method: (must be internal or user_token)", "authMethod", cfg.AuthMethod)
+	if cfg.AuthMethod != config.AuthMethodInternal && cfg.AuthMethod != config.AuthMethodUser && cfg.AuthMethod != config.AuthMethodRedHatUser {
+		logger.Error("invalid auth method: (must be internal or user_token or user_token_red_hat)", "authMethod", cfg.AuthMethod)
 		os.Exit(1)
 	}
 

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -17,6 +17,11 @@ const (
 	// AuthMethodUser uses a user-provided Bearer token for authentication.
 	AuthMethodUser = "user_token"
 
+	// AuthMethodRedHatUser is a Red Hat–specific variant of user token authentication.
+	// It allows injecting a custom Kubernetes client that wraps or extends the default behavior.
+	// Typically used to add custom functionality from RHOAI downstream.
+	AuthMethodRedHatUser = "user_token_red_hat"
+
 	// DefaultAuthTokenHeader is the standard header for Bearer token auth.
 	DefaultAuthTokenHeader = "Authorization"
 
@@ -85,7 +90,7 @@ type EnvConfig struct {
 
 	// ─── AUTH ───────────────────────────────────────────────────
 	// Specifies the authentication method used by the server.
-	// Valid values: "internal" or "user_token"
+	// Valid values: "internal" or "user_token" or "user_token_red_hat"
 	AuthMethod string
 
 	// Header used to extract the authentication token.
@@ -95,12 +100,6 @@ type EnvConfig struct {
 	// Optional prefix to strip from the token header value.
 	// Default is "Bearer ", can be set to empty if the token is sent without a prefix.
 	AuthTokenPrefix string
-
-	// ─── TLS ────────────────────────────────────────────────────
-	// TLS verification settings for HTTP client connections to Model Registry
-	// InsecureSkipVerify when true, skips TLS certificate verification (useful for development/local setups)
-	// Default is false (secure) for production environments
-	InsecureSkipVerify bool
 
 	// ─── DEPRECATED ─────────────────────────────────────────────
 	// The following fields are deprecated and maintained for backward compatibility

--- a/federated/kustomization.yaml
+++ b/federated/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: model-registry-ui-deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: model-registry-ui

--- a/federated/model-registry-ui-deployment.yaml
+++ b/federated/model-registry-ui-deployment.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/template/spec/containers/0/args
+  value: 
+    - "--deployment-mode=federated"
+    - "--port=8080"
+    - "--log-level=debug"
+    - "--auth-method=user_token_red_hat"

--- a/k8sfactory/k8sfactory.go
+++ b/k8sfactory/k8sfactory.go
@@ -1,0 +1,34 @@
+package k8sfactory
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	redhat "github.com/kubeflow/model-registry/ui/bff/internal/redhat/integrations/kubernetes"
+)
+
+func NewKubernetesClientFactory(cfg config.EnvConfig, logger *slog.Logger) (kubernetes.KubernetesClientFactory, error) {
+	switch cfg.AuthMethod {
+
+	case config.AuthMethodInternal:
+		k8sFactory, err := kubernetes.NewStaticClientFactory(logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create static client factory: %w", err)
+		}
+		return k8sFactory, nil
+
+	case config.AuthMethodUser:
+		k8sFactory := kubernetes.NewTokenClientFactory(logger, cfg)
+		return k8sFactory, nil
+
+	//TODO LUCAS red hat only code
+	case config.AuthMethodRedHatUser:
+		k8sFactory := redhat.NewRHOAIClientFactory(logger, cfg)
+		return k8sFactory, nil
+
+	default:
+		return nil, fmt.Errorf("invalid auth method: %q", cfg.AuthMethod)
+	}
+}

--- a/redhat/integrations/kubernetes/factory.go
+++ b/redhat/integrations/kubernetes/factory.go
@@ -1,0 +1,15 @@
+package kubernetes
+
+import (
+	"log/slog"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/config"
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+)
+
+// NewRHOAIClientFactory creates a KubernetesClientFactory used in RHOAI
+// when the authentication method is "user_token_red_hat".
+// It injects a custom Kubernetes client that wraps and extends the default behavior.
+func NewRHOAIClientFactory(logger *slog.Logger, cfg config.EnvConfig) kubernetes.KubernetesClientFactory {
+	return kubernetes.NewTokenClientFactoryWithCustomNewTokenKubernetesClientFn(logger, cfg, NewRHOAIKubernetesClient)
+}

--- a/redhat/integrations/kubernetes/k8s_client.go
+++ b/redhat/integrations/kubernetes/k8s_client.go
@@ -1,0 +1,190 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kubeflow/model-registry/ui/bff/internal/integrations/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var modelRegistryGVR = schema.GroupVersionResource{
+	Group:    "modelregistry.opendatahub.io",
+	Version:  "v1alpha1",
+	Resource: "modelregistries",
+}
+
+// OpenShift Groups GVR
+var groupGVR = schema.GroupVersionResource{
+	Group:    "user.openshift.io",
+	Version:  "v1",
+	Resource: "groups",
+}
+
+// RHOAITokenKubernetesClient wraps the default TokenKubernetesClient but overrides selected methods.
+// It also adds a dynamic client to the base client.
+type RHOAITokenKubernetesClient struct {
+	*kubernetes.TokenKubernetesClient
+	DynClient dynamic.Interface
+}
+
+func NewRHOAIKubernetesClient(token string, logger *slog.Logger) (kubernetes.KubernetesClientInterface, error) {
+	baseClient, err := kubernetes.NewTokenKubernetesClient(token, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base token client: %w", err)
+	}
+
+	typed := baseClient.(*kubernetes.TokenKubernetesClient)
+
+	dynClient, err := dynamic.NewForConfig(typed.RESTConfig())
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &RHOAITokenKubernetesClient{
+		TokenKubernetesClient: baseClient.(*kubernetes.TokenKubernetesClient),
+		DynClient:             dynClient,
+	}, nil
+}
+
+// GetGroups overrides the default stub logic with RHOAI-specific logic to fetch OpenShift groups.
+// This method queries the OpenShift user.openshift.io/v1 Group API to retrieve all available groups
+// that can be used for RBAC and permissions management in RHOAI.
+func (c *RHOAITokenKubernetesClient) GetGroups(ctx context.Context) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	c.Logger.Info("Fetching OpenShift groups for RHOAI")
+
+	// List all OpenShift groups using the dynamic client
+	// Note: Groups are cluster-scoped resources, so no namespace is specified
+	list, err := c.DynClient.
+		Resource(groupGVR).
+		List(ctx, v1.ListOptions{})
+	if err != nil {
+		c.Logger.Error("Failed to list OpenShift Groups", "error", err)
+		// Check if this is a permission error
+		if err.Error() != "" {
+			c.Logger.Warn("User may not have permissions to list groups cluster-wide")
+		}
+		return nil, fmt.Errorf("failed to list OpenShift groups: %w", err)
+	}
+
+	var groupNames []string
+	for _, item := range list.Items {
+		name, found, err := unstructured.NestedString(item.Object, "metadata", "name")
+		if err != nil {
+			c.Logger.Warn("Failed to extract group name", "error", err, "group", item.GetName())
+			continue
+		}
+		if !found || name == "" {
+			c.Logger.Warn("Group name not found or empty in metadata", "group", item.GetName())
+			continue
+		}
+		groupNames = append(groupNames, name)
+	}
+
+	c.Logger.Info("Successfully fetched OpenShift groups", "count", len(groupNames), "groups", groupNames)
+	return groupNames, nil
+}
+
+func (kc *RHOAITokenKubernetesClient) CreateModelRegistryKind(ctx context.Context, namespace string, modelRegistryKind unstructured.Unstructured, dryRun bool) (unstructured.Unstructured, error) {
+
+	opts := v1.CreateOptions{}
+	if dryRun {
+		opts.DryRun = []string{v1.DryRunAll}
+	}
+
+	created, err := kc.DynClient.
+		Resource(modelRegistryGVR).
+		Namespace(namespace).
+		Create(ctx, &modelRegistryKind, opts)
+
+	if err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to create ModelRegistryKind: %w", err)
+	}
+
+	return *created, nil
+}
+
+// GetModelRegistrySettings overrides the default stub logic with RHOAI-specific logic.
+func (c *RHOAITokenKubernetesClient) GetModelRegistrySettings(ctx context.Context, namespace string, labelSelector string) ([]unstructured.Unstructured, error) {
+
+	listOptions := v1.ListOptions{}
+	if labelSelector != "" {
+		listOptions.LabelSelector = labelSelector
+	}
+
+	list, err := c.DynClient.
+		Resource(modelRegistryGVR).
+		Namespace(namespace).
+		List(ctx, listOptions)
+	if err != nil {
+		c.Logger.Error("Failed to list ModelRegistry CRs", "error", err)
+		return nil, fmt.Errorf("failed to list ModelRegistry CRs in namespace %q: %w", namespace, err)
+	}
+
+	return list.Items, nil
+}
+
+func (c *RHOAITokenKubernetesClient) GetModelRegistrySettingsByName(ctx context.Context, namespace string, name string) (unstructured.Unstructured, error) {
+
+	result, err := c.DynClient.
+		Resource(modelRegistryGVR).
+		Namespace(namespace).
+		Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		c.Logger.Error("Failed to get ModelRegistry CR", "error", err, "name", name, "namespace", namespace)
+		return unstructured.Unstructured{}, fmt.Errorf("failed to get ModelRegistry %q in namespace %q: %w", name, namespace, err)
+	}
+
+	return *result, nil
+}
+
+func (c *RHOAITokenKubernetesClient) CreateDatabaseSecret(ctx context.Context, name string, namespace string, database string, databaseUsername string, databasePassword string, dryRun bool) (*corev1.Secret, error) {
+
+	if database == "" || databaseUsername == "" {
+		return nil, fmt.Errorf("invalid database config: database name or username missing")
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			GenerateName: name + "-db-",
+			Namespace:    namespace,
+			Annotations: map[string]string{
+				"template.openshift.io/expose-database_name": "{.data['database-name']}",
+				"template.openshift.io/expose-username":      "{.data['database-user']}",
+				"template.openshift.io/expose-password":      "{.data['database-password']}",
+			},
+			Labels: map[string]string{
+				"modelregistry.opendatahub.io/managed": "true",
+				"modelregistry.opendatahub.io/name":    name,
+			},
+		},
+		StringData: map[string]string{
+			"database-name":     database,
+			"database-user":     databaseUsername,
+			"database-password": databasePassword,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	options := v1.CreateOptions{}
+	if dryRun {
+		options.DryRun = []string{v1.DryRunAll}
+	}
+
+	created, err := c.Client.CoreV1().Secrets(namespace).Create(ctx, secret, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	return created, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Get model registries working for OpenShift

- The API stub are generated for specific bits
   - Get Groups
   - Get ModelRegistryKind
   - Get ModelRegistrySetting


## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

follow-up : https://github.com/kubeflow/model-registry/pull/1452
This brings in the API endpoint backend for the following API:

GET [/api/v1/settings/groups](https://github.com/kubeflow/model-registry/blob/16866854a787af1ecfd1fe28d5f97ee3a5d7f368/clients/ui/bff/internal/api/app.go#L40)
GET [/api/v1/settings/model_registry?namespace=](https://github.com/kubeflow/model-registry/blob/16866854a787af1ecfd1fe28d5f97ee3a5d7f368/clients/ui/bff/internal/api/app.go#L44)
GET /api/v1/settings/model_registry/{name}?namespace=

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed the BFF server, with following args

```
- "--deployment-mode=federated"
- "--port=8080"
- "--log-level=debug"
- "--auth-method=user_token_red_hat"
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [x] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Red Hat user token authentication, enabling enhanced OpenShift integration (group discovery and Model Registry management).
  - Introduced a federated deployment overlay; the UI can run in federated mode.

- Chores
  - Removed the option to disable TLS certificate verification; TLS is now always enforced.
  - Updated configuration validation and messages to include the new authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->