### PR TITLE
feat: add gha for building opendatahub/model-registry-testops image, fixes RHOAIENG-34922

### DIFF
--- a/.github/workflows/build-and-push-testops-image.yml
+++ b/.github/workflows/build-and-push-testops-image.yml
@@ -1,0 +1,122 @@
+name: Build and Push testops container image
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'stable'
+      - 'stable-2.x'
+    paths:
+      - 'Dockerfile.testops'
+      - 'clients/python/**'
+      - 'api/**'
+      - 'manifests/**'
+      - 'scripts/**'
+      - '!LICENSE*'
+      - '!**.gitignore'
+      - '!**.md'
+      - '!**.txt'
+      - '.github/workflows/build-and-push-testops-image.yml' # self
+
+permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule TokenPermissionsID
+  contents: read
+
+env:
+  IMG_REGISTRY: quay.io
+  IMG_ORG: opendatahub
+  IMG_NAME: model-registry-testops
+  REGISTRY_USER: ${{ secrets.QUAY_USERNAME }}
+  REGISTRY_PWD: ${{ secrets.QUAY_PASSWORD }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: github.repository == 'opendatahub-io/model-registry'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5.0.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.IMG_REGISTRY }}
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PWD }}
+
+    - name: Set branch-based environment
+      run: |
+        commit_sha=${{ github.sha }}
+        branch_name=${GITHUB_REF#refs/heads/}
+        tag=${branch_name}-${commit_sha:0:7}
+        # Calculate expiration date (7 days from now)
+        expiry_date=$(date -d '+7 days' -u +%Y-%m-%dT%H:%M:%SZ)
+        
+        echo "VERSION=${tag}" >> $GITHUB_ENV
+        echo "BRANCH_NAME=${branch_name}" >> $GITHUB_ENV
+        echo "EXPIRY_DATE=${expiry_date}" >> $GITHUB_ENV
+
+    - name: Set tag environment # this is for v* tag image build
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+
+    - name: Build and push SHA-based image (expires in 7 days)
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile.testops
+        push: true
+        tags: |
+          ${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_NAME }}:${{ env.VERSION }}
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+          quay.expires-after=7d
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        provenance: mode=max
+        sbom: true
+
+    - name: Build and push persistent branch tags (main)
+      if: github.ref == 'refs/heads/main'
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile.testops
+        push: true
+        tags: |
+          ${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_NAME }}:${{ env.BRANCH_NAME }}
+          ${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_NAME }}:latest
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        provenance: mode=max
+        sbom: true
+
+    - name: Build and push persistent branch tags (non-main)
+      if: github.ref != 'refs/heads/main'
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile.testops
+        push: true
+        tags: |
+          ${{ env.IMG_REGISTRY }}/${{ env.IMG_ORG }}/${{ env.IMG_NAME }}:${{ env.BRANCH_NAME }}
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        provenance: mode=max
+        sbom: true


### PR DESCRIPTION
Signed-off-by: Dhiraj Bokde <dhirajsb@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add gha for building opendatahub/model-registry-testops image
Fixes [RHOAIENG-34922](https://issues.redhat.com//browse/RHOAIENG-34922)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced an automated pipeline to build and publish TestOps container images on key branches and tagged releases.
  - Publishes commit-based and branch-based tags; releases use the tag as the version; main also updates the latest tag.
  - Generates SBOM and provenance, and uses caching for faster builds.
  - Supports short‑lived preview images with time-limited expiry metadata to simplify testing and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->