### PR TITLE
ci: display status in any case

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -66,8 +66,13 @@ jobs:
         run: |
           kubectl wait --for=condition=Available=true deployment/model-registry-db --timeout=5m
           kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
+      - name: Display KinD cluster status in any case
+        if: always()
+        run: |
           kubectl get deployments -o wide
           kubectl get pods -o wide
+          kubectl events
+          kubectl get modelregistries/modelregistry-sample -o wide
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -73,6 +73,7 @@ jobs:
           kubectl get pods -o wide
           kubectl events
           kubectl get modelregistries/modelregistry-sample -o wide
+          kubectl describe modelregistries/modelregistry-sample
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
to help to diagnose GHA failure issue, separate into separate GHA step and display K8s resource status

## How Has This Been Tested?
it is GHA modification, we can test this by looking into PR check execution

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * The CI image build pipeline now includes a final unconditional step that always outputs cluster status (deployments, pods, events, and sample registry resources) after the readiness/wait steps complete, ensuring consistent visibility into the environment’s state at the end of the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->