### PR TITLE
fix(catalog): default labels to an empty slice (#1822)

### DIFF
--- a/catalog/internal/catalog/loader.go
+++ b/catalog/internal/catalog/loader.go
@@ -156,6 +156,12 @@ func (l *Loader) read(path string) (*sourceConfig, error) {
 		}
 		// If not explicitly set, default to enabled
 		source.CatalogSource.Enabled = apiutils.Of(true)
+
+		// Default to an empty labels list
+		if source.Labels == nil {
+			source.Labels = []string{}
+		}
+
 		enabledSources = append(enabledSources, source)
 	}
 	config.Catalogs = enabledSources


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/RHOAIENG-37556

When loading sources, default labels to an empty slice so that the
sources endpoint never outputs `null` labels.

(cherry picked from commit b386e95180a9f1b05782f56bc076bf5eaf3f3872)

## How Has This Been Tested?
See originating PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
