### PR TITLE
Fix Python/Postgres tests on stable-2.x

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -58,6 +58,18 @@ jobs:
           echo "Deploying operator from model-registry-operator branch ${BRANCH}"
           kubectl apply -k "https://github.com/opendatahub-io/model-registry-operator.git/config/default?ref=${BRANCH}"
           kubectl set env -n model-registry-operator-system deployment/model-registry-operator-controller-manager REST_IMAGE="${IMG}"
+          kubectl wait --for=condition=Available=true -n model-registry-operator-system deployment/model-registry-operator-controller-manager --timeout=5m
+      - name: Display about MR Operator in KinD cluster status in any case
+        if: always()
+        run: |
+          kubectl get deployments -n model-registry-operator-system -o wide
+          kubectl get pods -n model-registry-operator-system -o wide --show-labels
+          kubectl events -A
+          kubectl describe -n model-registry-operator-system deployment/model-registry-operator-controller-manager
+          for p in $(kubectl get pods -n model-registry-operator-system -o name); do
+            echo "===== Logs for $p ====="
+            kubectl logs -n model-registry-operator-system $p
+          done
       - name: Create Test Registry
         run: |
           kubectl apply -k "https://github.com/opendatahub-io/model-registry-operator.git/config/samples/mysql?ref=${BRANCH}"
@@ -66,8 +78,14 @@ jobs:
         run: |
           kubectl wait --for=condition=Available=true deployment/model-registry-db --timeout=5m
           kubectl wait --for=condition=Available=true modelregistries/modelregistry-sample --timeout=5m
+      - name: Display KinD cluster status in any case
+        if: always()
+        run: |
           kubectl get deployments -o wide
           kubectl get pods -o wide
+          kubectl events
+          kubectl get modelregistries/modelregistry-sample -o wide
+          kubectl describe modelregistries/modelregistry-sample
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Description

The deployment created on the test during the tests uses the `latest` model-registry image and then immediately swaps it with the image from the branch. This is a problem on this branch because the database migrations run from the `latest` image first and applies up to migration number 25 (currently). However after the image has been swapped it only knows about migrations up to 21, so the migrations fail to apply and the pod goes into a crash loop. I'm not sure why this only affected Postgres.

## How Has This Been Tested?
In GHA on this PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
