### PR TITLE
Sync from upstream main

### DIFF
--- a/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
+++ b/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
@@ -75,13 +75,11 @@ class CatalogModel(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields were excluded:
+        "create_time_since_epoch" and "last_update_time_since_epoch" are now
+        being returned to properly test them in e2e test.
         """
-        excluded_fields: set[str] = set([
-            "create_time_since_epoch",
-            "last_update_time_since_epoch",
-        ])
+        excluded_fields: set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,

--- a/catalog/clients/python/src/catalog_openapi/models/filter_options_list.py
+++ b/catalog/clients/python/src/catalog_openapi/models/filter_options_list.py
@@ -82,7 +82,9 @@ class FilterOptionsList(BaseModel):
         if self.named_queries:
             for _key_named_queries in self.named_queries:
                 if self.named_queries[_key_named_queries]:
-                    _field_dict[_key_named_queries] = self.named_queries[_key_named_queries].to_dict()
+                    _field_dict[_key_named_queries] = self.named_queries[_key_named_queries] if isinstance(
+                        self.named_queries[_key_named_queries], dict) else self.named_queries[
+                        _key_named_queries].to_dict()
             _dict["namedQueries"] = _field_dict
         return _dict
 

--- a/catalog/clients/python/src/model_catalog/_client.py
+++ b/catalog/clients/python/src/model_catalog/_client.py
@@ -181,13 +181,14 @@ class CatalogAPIClient:
     # Maximum allowed timeout (5 minutes)
     MAX_TIMEOUT = 300
 
-    def __init__(self, base_url: str, timeout: int = 10, verify_ssl: bool = True):
+    def __init__(self, base_url: str, timeout: int = 10, verify_ssl: bool = True, access_token: str = None):
         """Initialize API client.
 
         Args:
             base_url: Base URL of the catalog service (e.g., http://localhost:8081)
             timeout: Request timeout in seconds (must be positive, max 300)
             verify_ssl: Whether to verify SSL certificates (default True)
+            access_token: Access token for authentication (default None)
 
         Raises:
             ValueError: If base_url is empty or invalid, or timeout is not positive.
@@ -210,9 +211,10 @@ class CatalogAPIClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.verify_ssl = verify_ssl
+        self.access_token = access_token
 
         # Configure the generated client
-        config = Configuration(host=self.base_url)
+        config = Configuration(host=self.base_url, access_token=self.access_token)
         config.verify_ssl = verify_ssl
         self.api_client = ApiClient(configuration=config)
         self._configure_timeout(config, timeout)

--- a/catalog/clients/python/tests/sorting_utils.py
+++ b/catalog/clients/python/tests/sorting_utils.py
@@ -1,0 +1,66 @@
+"""Utility functions for sorting tests."""
+
+import pytest
+from typing import Any
+
+
+def get_field_value(item: dict[str, Any], field: str) -> Any:
+    """Extract field value from an item for sorting comparison.
+
+    Args:
+        item: Model/item dictionary from API response
+        field: Field name (ID, CREATE_TIME, LAST_UPDATE_TIME)
+
+    Returns:
+        The field value, converted appropriately for comparison
+
+    Raises:
+        ValueError: If field is invalid or missing from item
+    """
+    field_mapping = {
+        "ID": "id",
+        "CREATE_TIME": "createTimeSinceEpoch",
+        "LAST_UPDATE_TIME": "lastUpdateTimeSinceEpoch",
+    }
+
+    if field not in field_mapping:
+        raise ValueError(f"Invalid field: {field}")
+
+    api_field = field_mapping[field]
+    value = item.get(api_field)
+
+    if value is None:
+        raise ValueError(f"Field {field} ({api_field}) is missing from item: {item}")
+
+    # Convert ID for proper numeric comparison
+    if field == "ID":
+        try:
+            return int(value)
+        except ValueError:
+            return str(value)
+
+    return value
+
+
+def validate_items_sorted_correctly(items: list[dict], field: str, order: str) -> bool:
+    """Verify items are sorted correctly by the specified field.
+
+    Args:
+        items: List of items to validate
+        field: Field name to check sorting on (ID, CREATE_TIME, LAST_UPDATE_TIME)
+        order: Sort order (ASC or DESC)
+
+    Returns:
+        True if items are sorted correctly, False otherwise
+    """
+    if len(items) < 2:
+        pytest.fail("List has fewer than 2 items, double check the data you are passing to this function")
+
+    values = [get_field_value(item, field) for item in items]
+
+    if order == "ASC":
+        return all(values[i] <= values[i + 1] for i in range(len(values) - 1))
+    elif order == "DESC":
+        return all(values[i] >= values[i + 1] for i in range(len(values) - 1))
+    else:
+        raise ValueError(f"Invalid sort order: {order}")

--- a/catalog/clients/python/tests/test_artifacts.py
+++ b/catalog/clients/python/tests/test_artifacts.py
@@ -24,7 +24,7 @@ class TestArtifacts:
     # === Basic Tests ===
 
     def test_get_artifacts_returns_response(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test that getting artifacts returns a response."""
         source_id, model_name = model_with_artifacts
@@ -33,7 +33,7 @@ class TestArtifacts:
         assert "items" in response
 
     def test_artifacts_have_expected_structure(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test that artifacts have expected structure."""
         source_id, model_name = model_with_artifacts
@@ -47,7 +47,7 @@ class TestArtifacts:
     # === Filtering Tests ===
 
     def test_filter_artifacts_by_model(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test filtering artifacts by model source and name."""
         source_id, model_name = model_with_artifacts
@@ -61,7 +61,7 @@ class TestArtifacts:
         assert len(artifacts) > 0, f"Expected artifacts for {model_name}"
 
     def test_filter_artifacts_by_query(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test filtering artifacts using filter query."""
         source_id, model_name = model_with_artifacts
@@ -95,7 +95,7 @@ class TestArtifacts:
                 assert props["framework_type"].get("string_value") == "pytorch"
 
     def test_filter_artifacts_by_numeric_property(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test filtering artifacts by numeric custom property."""
         source_id, model_name = model_with_artifacts
@@ -119,7 +119,8 @@ class TestArtifacts:
                 assert acc is not None, "Accuracy value is None"
                 assert acc > 0.9, f"Expected accuracy > 0.9, got {acc}"
 
-    def test_filter_artifacts_with_and_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]) -> None:
+    def test_filter_artifacts_with_and_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], 
+                                             suppress_ssl_warnings: None) -> None:
         """Test filtering artifacts with AND logic combining multiple conditions."""
         source_id, model_name = model_with_artifacts
 
@@ -148,7 +149,8 @@ class TestArtifacts:
             acc = props["accuracy"].get("double_value")
             assert acc is not None and acc > 0.5, f"Expected accuracy > 0.5, got {acc}"
 
-    def test_filter_artifacts_with_or_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]) -> None:
+    def test_filter_artifacts_with_or_logic(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str],
+                                           suppress_ssl_warnings: None) -> None:
         """Test filtering artifacts with OR logic combining multiple conditions."""
         source_id, model_name = model_with_artifacts
 
@@ -176,7 +178,8 @@ class TestArtifacts:
                 f"Expected framework_type to be 'pytorch' or 'onnx', got '{framework}'"
             )
 
-    def test_filter_artifacts_returns_empty_for_no_matches(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]) -> None:
+    def test_filter_artifacts_returns_empty_for_no_matches(self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str],
+                                                          suppress_ssl_warnings: None) -> None:
         """Test that a valid filter query with no matching artifacts returns empty results."""
         source_id, model_name = model_with_artifacts
 
@@ -193,7 +196,7 @@ class TestArtifacts:
         assert response["items"] == [], "Expected empty results for non-matching filter"
         assert response.get("size", 0) == 0, "Expected size to be 0 for non-matching filter"
 
-    def test_multiple_models_have_different_artifacts(self, api_client: CatalogAPIClient) -> None:
+    def test_multiple_models_have_different_artifacts(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None) -> None:
         """Test that different models have their own artifacts."""
         models = api_client.get_models()
         if not models.get("items") or len(models["items"]) < 2:
@@ -221,7 +224,7 @@ class TestArtifacts:
     # === Ordering Tests ===
 
     def test_artifacts_have_ordering_fields(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test artifacts have timestamp fields for ordering."""
         source_id, model_name = model_with_artifacts
@@ -245,7 +248,7 @@ class TestArtifacts:
             assert has_ordering_field, "Artifact missing ordering fields"
 
     def test_artifacts_have_identifiers(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test artifacts can be identified by name/id."""
         source_id, model_name = model_with_artifacts
@@ -268,7 +271,7 @@ class TestArtifacts:
         assert len(identifiers) > 0, "No artifact identifiers found"
 
     def test_artifacts_pagination(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test artifacts support pagination."""
         source_id, model_name = model_with_artifacts
@@ -287,7 +290,7 @@ class TestArtifacts:
         assert "pageSize" in response or "size" in response
 
     def test_artifacts_custom_properties(
-        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str]
+        self, api_client: CatalogAPIClient, model_with_artifacts: tuple[str, str], suppress_ssl_warnings: None
     ) -> None:
         """Test that artifacts with custom properties are valid."""
         source_id, model_name = model_with_artifacts

--- a/catalog/clients/python/tests/test_filter_options.py
+++ b/catalog/clients/python/tests/test_filter_options.py
@@ -16,20 +16,20 @@ from model_catalog import CatalogAPIClient
 class TestFilterOptions:
     """Test suite for filter options functionality."""
 
-    def test_get_filter_options_returns_response(self, api_client: CatalogAPIClient):
+    def test_get_filter_options_returns_response(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that filter options endpoint returns a response."""
         response = api_client.get_filter_options()
         assert response is not None, "Filter options response should not be None"
         assert isinstance(response, dict)
 
-    def test_filter_options_has_filters_field(self, api_client: CatalogAPIClient):
+    def test_filter_options_has_filters_field(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that filter options response has filters field."""
         response = api_client.get_filter_options()
         filters = response["filters"]
         assert isinstance(filters, dict)
         assert len(filters) > 0, "Filters object should not be empty"
 
-    def test_filter_options_contains_field_types(self, api_client: CatalogAPIClient):
+    def test_filter_options_contains_field_types(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that filter options contains field type information."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -45,7 +45,7 @@ class TestFilterOptions:
                 f"Field {field_name} has unknown type '{field_info['type']}'. Known types: {known_types}"
             )
 
-    def test_string_filters_have_values(self, api_client: CatalogAPIClient):
+    def test_string_filters_have_values(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that string type filters have available values."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -55,7 +55,7 @@ class TestFilterOptions:
                 assert "values" in field_info, f"String field {field_name} missing values"
                 assert isinstance(field_info["values"], list)
 
-    def test_number_filters_have_range(self, api_client: CatalogAPIClient):
+    def test_number_filters_have_range(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that number type filters have range information."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -71,7 +71,7 @@ class TestFilterOptions:
 class TestFilterValidation:
     """Test suite for filter validation."""
 
-    def test_filter_types_are_valid(self, api_client: CatalogAPIClient):
+    def test_filter_types_are_valid(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that filter types are valid enumeration values."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -85,7 +85,7 @@ class TestFilterValidation:
                 f"Unknown type '{field_type}' for field {field_name}. Known types: {known_types}"
             )
 
-    def test_number_ranges_are_valid(self, api_client: CatalogAPIClient):
+    def test_number_ranges_are_valid(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that number ranges have valid min <= max."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -99,7 +99,7 @@ class TestFilterValidation:
                 if min_val is not None and max_val is not None:
                     assert min_val <= max_val, f"Invalid range for {field_name}: min={min_val}, max={max_val}"
 
-    def test_string_values_are_non_empty(self, api_client: CatalogAPIClient):
+    def test_string_values_are_non_empty(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that string filter values are non-empty lists of strings."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -109,10 +109,12 @@ class TestFilterValidation:
                 values = field_info.get("values", [])
                 assert isinstance(values, list), f"Values for {field_name} should be a list"
                 for idx, val in enumerate(values):
-                    assert isinstance(val, str), f"Value at index {idx} in {field_name} should be string, got {type(val)}"
+                    assert isinstance(val, str), (
+                        f"Value at index {idx} in {field_name} should be string, got {type(val)}"
+                    )
                     assert val.strip(), f"Value at index {idx} in {field_name} should not be empty or whitespace"
 
-    def test_string_values_are_distinct(self, api_client: CatalogAPIClient):
+    def test_string_values_are_distinct(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that string filter values contain no duplicates."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -124,7 +126,7 @@ class TestFilterValidation:
                     f"Values for '{field_name}' should be distinct (found duplicates)"
                 )
 
-    def test_filter_field_names_format(self, api_client: CatalogAPIClient):
+    def test_filter_field_names_format(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that filter field names follow expected format."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})
@@ -142,7 +144,7 @@ class TestFilterValidation:
 class TestNamedQueries:
     """Test suite for named queries functionality."""
 
-    def test_named_queries_structure(self, api_client: CatalogAPIClient):
+    def test_named_queries_structure(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that named queries have proper structure if present."""
         response = api_client.get_filter_options()
 
@@ -154,7 +156,7 @@ class TestNamedQueries:
                 assert isinstance(query_name, str)
                 assert isinstance(query_def, dict)
 
-    def test_named_queries_operators_are_valid(self, api_client: CatalogAPIClient):
+    def test_named_queries_operators_are_valid(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that named query operators are valid if present."""
         response = api_client.get_filter_options()
 
@@ -171,7 +173,7 @@ class TestNamedQueries:
                     if operator:
                         assert operator in valid_operators, f"Invalid operator '{operator}' in query {query_name}"
 
-    def test_filter_options_artifact_properties(self, api_client: CatalogAPIClient):
+    def test_filter_options_artifact_properties(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that artifact custom properties appear in filter options."""
         response = api_client.get_filter_options()
         filters = response.get("filters", {})

--- a/catalog/clients/python/tests/test_ordering.py
+++ b/catalog/clients/python/tests/test_ordering.py
@@ -68,28 +68,30 @@ def _model_has_accuracy(model: dict[str, Any]) -> bool:
 class TestNameOrdering:
     """Test suite for NAME ordering functionality."""
 
-    def test_order_by_name_asc(self, api_client: CatalogAPIClient):
+    def test_order_by_name_asc(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that ordering by name ASC returns models."""
         response = api_client.get_models(order_by="name", sort_order="ASC")
         _assert_response_valid(response)
 
-    def test_order_by_name_desc(self, api_client: CatalogAPIClient):
+    def test_order_by_name_desc(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that ordering by name DESC returns models."""
         response = api_client.get_models(order_by="name", sort_order="DESC")
         _assert_response_valid(response)
 
-    def test_name_asc_vs_desc_are_reversed(self, api_client: CatalogAPIClient):
+    def test_name_asc_vs_desc_are_reversed(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None,
+                                           kind_cluster: bool):
         """Test that ASC and DESC orderings are reversed."""
         # Use large page size to get all models
-        response_asc = api_client.get_models(order_by="name", sort_order="ASC", page_size=100)
-        response_desc = api_client.get_models(order_by="name", sort_order="DESC", page_size=100)
+        page_size = 100 if kind_cluster else 1000
+        response_asc = api_client.get_models(order_by="name", sort_order="ASC", page_size=page_size)
+        response_desc = api_client.get_models(order_by="name", sort_order="DESC", page_size=page_size)
 
         if response_asc["items"] and len(response_asc["items"]) > 1:
             names_asc = [m["name"] for m in response_asc["items"]]
             names_desc = [m["name"] for m in response_desc["items"]]
             assert names_asc == list(reversed(names_desc))
 
-    def test_name_ordering_consistent(self, api_client: CatalogAPIClient):
+    def test_name_ordering_consistent(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test name ordering returns consistent results."""
         response = api_client.get_models(order_by="name", sort_order="ASC")
         _assert_response_valid(response)
@@ -103,7 +105,7 @@ class TestNameOrdering:
             names2 = [m["name"] for m in response2["items"]]
             assert names == names2
 
-    def test_name_ordering_pagination_maintains_order(self, api_client: CatalogAPIClient):
+    def test_name_ordering_pagination_maintains_order(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that pagination maintains ordering.
 
         Note: Uses nextPageToken from first response. This is safe because test data
@@ -177,19 +179,19 @@ class TestFieldOrdering:
 class TestAccuracyOrdering:
     """Test suite for ACCURACY ordering functionality."""
 
-    def test_order_by_accuracy_desc(self, api_client: CatalogAPIClient):
+    def test_order_by_accuracy_desc(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that orderBy=ACCURACY with sortOrder=DESC returns a valid response."""
         response = api_client.get_models(order_by="ACCURACY", sort_order="DESC")
         assert isinstance(response, dict)
         assert "items" in response
 
-    def test_order_by_accuracy_asc(self, api_client: CatalogAPIClient):
+    def test_order_by_accuracy_asc(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that orderBy=ACCURACY with sortOrder=ASC returns a valid response."""
         response = api_client.get_models(order_by="ACCURACY", sort_order="ASC")
         assert isinstance(response, dict)
         assert "items" in response
 
-    def test_accuracy_desc_sorts_correctly(self, api_client: CatalogAPIClient):
+    def test_accuracy_desc_sorts_correctly(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that orderBy=ACCURACY DESC returns models in descending accuracy order."""
         response = api_client.get_models(order_by="ACCURACY", sort_order="DESC")
         items = response.get("items", [])
@@ -209,7 +211,7 @@ class TestAccuracyOrdering:
             for i in range(len(accuracies) - 1):
                 assert accuracies[i] >= accuracies[i + 1], f"Accuracies not in descending order: {accuracies}"
 
-    def test_models_without_accuracy_come_last(self, api_client: CatalogAPIClient):
+    def test_models_without_accuracy_come_last(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that models without accuracy metrics come last (NULLS LAST)."""
         response = api_client.get_models(order_by="ACCURACY", sort_order="DESC")
         items = response.get("items", [])
@@ -231,7 +233,7 @@ class TestAccuracyOrdering:
             "Found model with accuracy after model without - NULLS LAST violated"
         )
 
-    def test_accuracy_sorting_with_pagination(self, api_client: CatalogAPIClient):
+    def test_accuracy_sorting_with_pagination(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that accuracy sorting works correctly with pagination."""
         response1 = api_client.get_models(
             order_by="ACCURACY",
@@ -254,7 +256,7 @@ class TestAccuracyOrdering:
         all_items = response1["items"] + response2["items"]
         assert len(all_items) >= 2
 
-    def test_accuracy_sorting_returns_all_models(self, api_client: CatalogAPIClient):
+    def test_accuracy_sorting_returns_all_models(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that accuracy sorting returns all models, not just those with accuracy."""
         response_all = api_client.get_models()
         all_count = len(response_all.get("items", []))
@@ -264,7 +266,7 @@ class TestAccuracyOrdering:
 
         assert sorted_count == all_count, f"Sorted count ({sorted_count}) != all count ({all_count})"
 
-    def test_accuracy_metrics_structure(self, api_client: CatalogAPIClient):
+    def test_accuracy_metrics_structure(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that accuracy metrics are stored as custom properties on artifacts."""
         response = api_client.get_models()
         items = response.get("items", [])

--- a/catalog/clients/python/tests/test_source_preview.py
+++ b/catalog/clients/python/tests/test_source_preview.py
@@ -20,7 +20,7 @@ class TestSourcePreview:
     without modifying the running service state.
     """
 
-    def test_preview_valid_source_config(self, api_client: CatalogAPIClient):
+    def test_preview_valid_source_config(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test previewing a valid source configuration."""
         # Preview expects a flat config with inline catalog data
         config_content = """
@@ -40,7 +40,7 @@ models:
         assert "items" in response
 
     @pytest.mark.huggingface
-    def test_preview_huggingface_source(self, api_client: CatalogAPIClient):
+    def test_preview_huggingface_source(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test previewing a HuggingFace source configuration.
 
         HuggingFace preview works without credentials for public models.
@@ -65,7 +65,7 @@ includedModels:
         model_names = [item.get("name") for item in items]
         assert "openai-community/gpt2" in model_names
 
-    def test_preview_yaml_source(self, api_client: CatalogAPIClient):
+    def test_preview_yaml_source(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test previewing a YAML catalog source with inline data."""
         # Preview expects a flat config, not the full sources.yaml structure
         config_content = """
@@ -89,13 +89,13 @@ models:
         model_names = [m.get("name") for m in items]
         assert "preview-model" in model_names, f"Expected 'preview-model' in {model_names}"
 
-    def test_preview_invalid_config_returns_error(self, api_client: CatalogAPIClient):
+    def test_preview_invalid_config_returns_error(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that previewing invalid config returns an error."""
         invalid_config = "not: valid: yaml: config: [[[]]"
         with pytest.raises((CatalogValidationError, CatalogAPIError)):
             api_client.preview_source(config_content=invalid_config)
 
-    def test_preview_empty_config(self, api_client: CatalogAPIClient):
+    def test_preview_empty_config(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test previewing with empty/minimal config.
 
         The server may either:
@@ -117,7 +117,7 @@ catalogs: []
             # Server may reject empty catalogs as invalid - this is acceptable
             pass
 
-    def test_preview_response_structure(self, api_client: CatalogAPIClient):
+    def test_preview_response_structure(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that preview response has expected structure."""
         # Preview expects a flat config, not the full sources.yaml structure
         config_content = """

--- a/catalog/clients/python/tests/test_sources.py
+++ b/catalog/clients/python/tests/test_sources.py
@@ -18,19 +18,19 @@ from model_catalog import CatalogAPIClient
 class TestSourceBasics:
     """Test suite for basic source functionality."""
 
-    def test_get_sources_returns_response(self, api_client: CatalogAPIClient):
+    def test_get_sources_returns_response(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that getting sources returns a response with items."""
         response = api_client.get_sources()
         assert isinstance(response, dict)
         assert "items" in response
         assert isinstance(response["items"], list)
 
-    def test_sources_exist(self, api_client: CatalogAPIClient):
+    def test_sources_exist(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that at least one source is configured."""
         response = api_client.get_sources()
         assert len(response["items"]) > 0, "Expected at least one source"
 
-    def test_source_required_fields(self, api_client: CatalogAPIClient):
+    def test_source_required_fields(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that sources have all required fields."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -41,7 +41,7 @@ class TestSourceBasics:
             # Required: status indicator
             assert "enabled" in source or "status" in source, f"Source {source.get('id')} missing status indicator"
 
-    def test_source_ids_are_unique(self, api_client: CatalogAPIClient):
+    def test_source_ids_are_unique(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that sources have unique IDs."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -51,7 +51,7 @@ class TestSourceBasics:
 
         assert len(source_ids) == len(unique_ids), f"Duplicate source IDs found: {source_ids}"
 
-    def test_source_pagination_fields(self, api_client: CatalogAPIClient):
+    def test_source_pagination_fields(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that sources response includes pagination fields."""
         response = api_client.get_sources()
         # Response should have pagination info (size or pageSize)
@@ -62,7 +62,7 @@ class TestSourceBasics:
 class TestSourceStatus:
     """Test suite for source status functionality."""
 
-    def test_sources_have_status_field(self, api_client: CatalogAPIClient):
+    def test_sources_have_status_field(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that sources have a status field."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -71,7 +71,7 @@ class TestSourceStatus:
             assert isinstance(source, dict)
             assert "status" in source or "enabled" in source
 
-    def test_enabled_source_returns_models(self, api_client: CatalogAPIClient):
+    def test_enabled_source_returns_models(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that enabled sources return models."""
         sources = api_client.get_sources()
         assert sources.get("items"), "No sources found"
@@ -98,7 +98,7 @@ class TestSourceStatus:
         assert "items" in models
         assert len(models.get("items", [])) > 0, f"Expected models from enabled source {source_id}"
 
-    def test_disabled_source_excluded_from_models(self, api_client: CatalogAPIClient):
+    def test_disabled_source_excluded_from_models(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that disabled sources are excluded from model results."""
         sources = api_client.get_sources()
         if not sources.get("items"):
@@ -133,7 +133,7 @@ class TestSourceStatus:
                 f"Model {model.get('name')} from disabled source {disabled_source_id} should not appear in results"
             )
 
-    def test_source_status_values(self, api_client: CatalogAPIClient):
+    def test_source_status_values(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that source status has expected values."""
         sources = api_client.get_sources()
         assert sources.get("items"), "No sources found"
@@ -148,7 +148,7 @@ class TestSourceStatus:
                 valid_statuses = {"available", "disabled", "error", "loading", "pending"}
                 assert status in valid_statuses, f"Unexpected status: {status}"
 
-    def test_enabled_and_status_consistency(self, api_client: CatalogAPIClient):
+    def test_enabled_and_status_consistency(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that enabled flag and status are consistent."""
         sources = api_client.get_sources()
         assert sources.get("items"), "No sources found"
@@ -163,7 +163,7 @@ class TestSourceStatus:
                 if enabled is False:
                     assert status == "disabled", f"Source {source.get('id')} has enabled=False but status={status}"
 
-    def test_disabled_sources_in_response(self, api_client: CatalogAPIClient):
+    def test_disabled_sources_in_response(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that disabled sources appear in response with correct status."""
         response = api_client.get_sources()
         if not response.get("items"):
@@ -185,13 +185,13 @@ class TestSourceStatus:
 class TestSourcePaths:
     """Test suite for source path configurations."""
 
-    def test_sources_are_loaded(self, api_client: CatalogAPIClient):
+    def test_sources_are_loaded(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that sources configured with paths are properly loaded."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
         assert len(response["items"]) > 0
 
-    def test_source_status_indicates_path_resolution(self, api_client: CatalogAPIClient):
+    def test_source_status_indicates_path_resolution(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that source status indicates whether paths were resolved correctly."""
         response = api_client.get_sources()
 
@@ -203,7 +203,7 @@ class TestSourcePaths:
             if status == "error":
                 assert error is not None, f"Source {source.get('id')} has error status but no error message"
 
-    def test_available_sources_exist(self, api_client: CatalogAPIClient):
+    def test_available_sources_exist(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that available sources exist (paths resolved correctly)."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -211,7 +211,7 @@ class TestSourcePaths:
         available_sources = [s for s in response["items"] if s.get("status") == "available"]
         assert len(available_sources) > 0, "No available sources found"
 
-    def test_models_from_path_configured_sources(self, api_client: CatalogAPIClient):
+    def test_models_from_path_configured_sources(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that models are loaded from path-configured sources."""
         sources = api_client.get_sources()
         models = api_client.get_models()
@@ -221,7 +221,7 @@ class TestSourcePaths:
         if available_sources:
             assert models.get("items"), "Expected models from available sources"
 
-    def test_source_error_messages_are_helpful(self, api_client: CatalogAPIClient):
+    def test_source_error_messages_are_helpful(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that source error messages indicate path issues."""
         response = api_client.get_sources()
 
@@ -232,7 +232,7 @@ class TestSourcePaths:
                 assert isinstance(error, str)
                 assert len(error) > 0
 
-    def test_source_error_field_consistency(self, api_client: CatalogAPIClient):
+    def test_source_error_field_consistency(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that error field is consistent with source status."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -258,7 +258,7 @@ class TestSourcePaths:
 class TestSourceMerge:
     """Test suite for source merge functionality."""
 
-    def test_source_merge_priority(self, api_client: CatalogAPIClient):
+    def test_source_merge_priority(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that source merge respects priority ordering."""
         response = api_client.get_sources()
         assert response.get("items"), "No sources found"
@@ -268,11 +268,13 @@ class TestSourceMerge:
             status = source.get("status")
 
             if enabled is True:
-                assert status in ["available", "error", None], f"Source {source.get('id')} has enabled=True but status={status}"
+                assert status in ["available", "error", None], (
+                    f"Source {source.get('id')} has enabled=True but status={status}"
+                )
             if enabled is False:
                 assert status in ["disabled", None], f"Source {source.get('id')} has enabled=False but status={status}"
 
-    def test_source_merge_labels(self, api_client: CatalogAPIClient):
+    def test_source_merge_labels(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that source merge correctly handles labels."""
         response = api_client.get_sources()
 
@@ -282,7 +284,7 @@ class TestSourceMerge:
             for label in labels:
                 assert isinstance(label, str)
 
-    def test_enabled_sources_return_models(self, api_client: CatalogAPIClient):
+    def test_enabled_sources_return_models(self, api_client: CatalogAPIClient, suppress_ssl_warnings: None):
         """Test that enabled merged sources return models."""
         sources = api_client.get_sources()
         assert sources.get("items"), "No sources found"

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/tensorTypeComparisonCard.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/tensorTypeComparisonCard.cy.ts
@@ -170,9 +170,10 @@ describe('Compression Level Comparison Card', () => {
       modelCatalog.findCompressionDivider(3).should('exist');
     });
 
-    it('should navigate to variant model when clicking link', () => {
+    it('should navigate to variant model Performance Insights tab when clicking link', () => {
       modelCatalog.findCompressionVariantLink(1).click();
-      cy.url().should('include', encodeURIComponent('repo1/granite-8b-int4'));
+      cy.url().should('include', 'granite-8b-int4');
+      cy.url().should('include', 'performance-insights');
     });
   });
 
@@ -232,11 +233,20 @@ describe('Compression Level Comparison Card', () => {
       visitPerformanceTab(mockVariantModels[0].name);
     });
 
-    it('should display empty alert when no variants found', () => {
-      modelCatalog.findCompressionComparisonEmpty().should('exist');
-      modelCatalog
-        .findCompressionComparisonEmpty()
-        .should('contain', 'No compression variants found');
+    it('should NOT display the card when no variants found', () => {
+      modelCatalog.findCompressionComparisonCard().should('not.exist');
+    });
+  });
+
+  describe('Single variant state', () => {
+    beforeEach(() => {
+      // Only the current model is returned as a variant
+      initIntercepts({ variantModels: [mockVariantModels[0]] });
+      visitPerformanceTab(mockVariantModels[0].name);
+    });
+
+    it('should NOT display the card when there is only one variant (the current model)', () => {
+      modelCatalog.findCompressionComparisonCard().should('not.exist');
     });
   });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelPerformanceViewToggleCard.scss
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelPerformanceViewToggleCard.scss
@@ -1,0 +1,6 @@
+.model-performance-switch.pf-v6-c-switch {
+  --pf-v6-c-switch__input--checked__toggle--BackgroundColor: var(
+    --pf-t--global--icon--color--status--info--default
+  );
+  --pf-v6-c-switch--ColumnGap: var(--pf-t--global--spacer--md);
+}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelPerformanceViewToggleCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/ModelPerformanceViewToggleCard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { ChartBarIcon } from '@patternfly/react-icons';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
+import './ModelPerformanceViewToggleCard.scss';
 
 const ModelPerformanceViewToggleCard: React.FC = () => {
   const { performanceViewEnabled, setPerformanceViewEnabled, filterOptionsLoaded } =
@@ -22,9 +23,12 @@ const ModelPerformanceViewToggleCard: React.FC = () => {
       <CardBody>
         <Stack hasGutter>
           <StackItem>
-            <Flex>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsXs' }}
+            >
               <FlexItem>
-                <ChartBarIcon />
+                <ChartBarIcon color="var(--pf-t--global--icon--color--status--info--default)" />
               </FlexItem>
               <FlexItem>
                 <Switch
@@ -35,6 +39,7 @@ const ModelPerformanceViewToggleCard: React.FC = () => {
                   isDisabled={!filterOptionsLoaded}
                   onChange={(_event, checked) => setPerformanceViewEnabled(checked)}
                   data-testid="model-performance-view-toggle"
+                  className="model-performance-switch"
                 />
               </FlexItem>
             </Flex>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/TensorTypeComparisonCard.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/TensorTypeComparisonCard.tsx
@@ -16,10 +16,10 @@ import React from 'react';
 import { Link } from 'react-router';
 import { useCatalogModelsBySources } from '~/app/hooks/modelCatalog/useCatalogModelsBySource';
 import { CatalogModel } from '~/app/modelCatalogTypes';
-import { catalogModelDetailsFromModel } from '~/app/routes/modelCatalog/catalogModel';
+import { catalogModelDetailsTabFromModel } from '~/app/routes/modelCatalog/catalogModel';
 import { getStringValue } from '~/app/utils';
 import { getModelName } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
-import { EMPTY_CUSTOM_PROPERTY_VALUE } from '~/concepts/modelCatalog/const';
+import { EMPTY_CUSTOM_PROPERTY_VALUE, ModelDetailsTab } from '~/concepts/modelCatalog/const';
 import { sortModelsWithCurrentFirst } from '~/app/pages/modelCatalog/utils/validatedModelUtils';
 
 type TensorTypeComparisonCardProps = {
@@ -45,7 +45,13 @@ const TensorTypeComparisonCard: React.FC<TensorTypeComparisonCardProps> = ({ mod
     [catalogModels.items, model.name],
   );
 
+  // Hide the card if there's no variant group ID
   if (!variantGroupId || variantGroupId === EMPTY_CUSTOM_PROPERTY_VALUE) {
+    return null;
+  }
+
+  // Hide the card if there's only one variant (the current model)
+  if (catalogModelsLoaded && !catalogModelsLoadError && sortedModels.length <= 1) {
     return null;
   }
 
@@ -80,13 +86,6 @@ const TensorTypeComparisonCard: React.FC<TensorTypeComparisonCardProps> = ({ mod
               </Alert>
             ) : !catalogModelsLoaded ? (
               <Spinner size="lg" data-testid="compression-comparison-loading" />
-            ) : sortedModels.length === 0 ? (
-              <Alert
-                variant="info"
-                isInline
-                title="No compression variants found"
-                data-testid="compression-comparison-empty"
-              />
             ) : (
               <Flex
                 gap={{ default: 'gapMd' }}
@@ -158,8 +157,9 @@ const TensorTypeComparisonCard: React.FC<TensorTypeComparisonCardProps> = ({ mod
                                   />
                                 ) : (
                                   <Link
-                                    to={catalogModelDetailsFromModel(
-                                      encodeURIComponent(variant.name || ''),
+                                    to={catalogModelDetailsTabFromModel(
+                                      ModelDetailsTab.PERFORMANCE_INSIGHTS,
+                                      variant.name || '',
                                       variant.source_id,
                                     )}
                                     data-testid={`compression-link-${index}`}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.ts
@@ -35,12 +35,12 @@ export const HELP_TEXT = {
   ACCESS_TOKEN:
     'Enter your fine-grained Hugging Face access token. Public models can be pulled into catalog without an access token. For private/gated models, a token is recommended to ensure full metadata is displayed, otherwise only limited metadata may be available. The token must have the following permissions: read repos in your namespace, read public repos that you can access.',
   ORGANIZATION:
-    'Enter the name of the organization (for example, Google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
+    'Enter the name of the organization (for example, google) to sync models from. Hugging Face sources are limited to 1 organization to prevent performance issues related to loading large model sets.',
   YAML: 'Upload or paste a YAML string.',
 } as const;
 
 export const PLACEHOLDERS = {
-  ORGANIZATION: 'Example: Google',
+  ORGANIZATION: 'Example: google',
   ALLOWED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b*)',
   ALLOWED_MODELS_GENERIC: 'Example: Google/gemma-7b*, Meta/Llama-3.1-8B-Instruct',
   EXCLUDED_MODELS_HF: 'Enter model names, one per line (e.g., gemma-7b-test*)',

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/screens/CatalogSourceConfigsTableColumns.tsx
@@ -16,7 +16,7 @@ export const catalogSourceConfigsColumns: SortableData<CatalogSourceConfig>[] = 
     sortable: false,
     info: {
       popover:
-        'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, Google). Only models within this organization are included in the catalog.',
+        'Applies only to Hugging Face sources. Shows the organization the source syncs models from (for example, google). Only models within this organization are included in the catalog.',
     },
     width: 15,
   },

--- a/manifests/kustomize/options/catalog/overlays/e2e/test-catalog.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/test-catalog.yaml
@@ -5,6 +5,10 @@ models:
   # Models with artifacts and accuracy for ordering/filtering tests
   - name: test-model-1
     description: Primary test model with high accuracy
+    createTimeSinceEpoch: "1700000000000"
+    lastUpdateTimeSinceEpoch: "1700100000000"
+    tasks:
+      - text-generation
     customProperties:
       size:
         metadataType: MetadataStringValue
@@ -31,6 +35,10 @@ models:
 
   - name: test-model-2
     description: Secondary test model with medium accuracy
+    createTimeSinceEpoch: "1700200000000"
+    lastUpdateTimeSinceEpoch: "1700300000000"
+    tasks:
+      - text-generation
     customProperties:
       size:
         metadataType: MetadataStringValue
@@ -57,6 +65,10 @@ models:
 
   - name: test-model-3
     description: Third test model with low accuracy
+    createTimeSinceEpoch: "1700400000000"
+    lastUpdateTimeSinceEpoch: "1700250000000"
+    tasks:
+      - text-generation
     artifacts:
       - name: tensorrt-artifact
         uri: s3://bucket/test-model-3.tar.gz


### PR DESCRIPTION
- **Add a way to pass user token to CatalogAPIClient (#2192)**
- **[reopening #2148] Add ordering tests for catalog e2e from downstream (#2187)**
- **test: add artifact filtering tests for type and query validation (#2184)**
- **Make changes to tests to add support to run them against openshift clusters (#2195)**
- **Microcopy and UX fixes to model catalog (#2196)**

@coderabbitai ignore
