### PR TITLE
chore: Add support to run async tests against openshift clusters

### DIFF
--- a/jobs/async-upload/Makefile
+++ b/jobs/async-upload/Makefile
@@ -4,6 +4,7 @@ JOB_IMG_ORG ?= opendatahub
 JOB_IMG_NAME ?= model-registry-job-async-upload
 JOB_IMG ?= $(JOB_IMG_REGISTRY)/$(JOB_IMG_ORG)/$(JOB_IMG_NAME):$(JOB_IMG_VERSION)
 BUILD_IMAGE ?= true # whether to build the MR server image
+include odh_rules.mk
 CLUSTER_NAME ?= mr-e2e
 
 # MR Server Params
@@ -100,3 +101,13 @@ install: install-poetry-export
 .PHONY: install-poetry-export
 install-poetry-export:
 	poetry self add poetry-plugin-export
+
+.PHONY: undeploy-minio
+undeploy-minio:
+	@echo "Undeploy Minio..."
+	cd ../../ && ./scripts/undeploy_minio.sh
+
+.PHONY: undeploy-local-kind-registry
+undeploy-local-kind-registry:
+	@echo "Undeploy Local Kind Registry..."
+	cd ../../ && ./scripts/undeploy_local_registry.sh

--- a/jobs/async-upload/odh_rules.mk
+++ b/jobs/async-upload/odh_rules.mk
@@ -1,0 +1,33 @@
+.PHONY: deploy-mr-odh
+deploy-mr-odh:
+	cd ../../ && ./scripts/deploy_on_odh.sh
+
+.PHONY: undeploy-mr-odh
+undeploy-mr-odh:
+	cd ../../ && ./scripts/undeploy_on_odh.sh
+
+.PHONY: test-e2e-odh
+test-e2e-odh: deploy-mr-odh deploy-local-registry deploy-test-minio
+	@echo "Running e2e tests..."
+	@set -a; . ../../scripts/manifests/minio/.env; set +a; \
+	mkdir -p ../../results; \
+	export AUTH_TOKEN=$$(kubectl config view --raw -o jsonpath="{.users[?(@.name==\"$$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$$(kubectl config current-context)\")].context.user}")\")].user.token}") && \
+	export VERIFY_SSL=False && \
+	export MR_NAMESPACE=$$(kubectl get datasciencecluster default-dsc -o jsonpath='{.spec.components.modelregistry.registriesNamespace}') && \
+	export MR_HOST_URL="https://$$(kubectl get service -n "$$MR_NAMESPACE" model-registry -o jsonpath='{.metadata.annotations.routing\.opendatahub\.io\/external-address-rest}')" && \
+	export MR_ENDPOINT=$$(kubectl get service -n "$$MR_NAMESPACE" model-registry -o jsonpath='{.metadata.annotations.routing\.opendatahub\.io\/external-address-rest}' | cut -d: -f1) && \
+	export MODEL_SYNC_REGISTRY_SERVER_ADDRESS="https://$$MR_ENDPOINT" && \
+	export MODEL_SYNC_REGISTRY_PORT="443" && \
+	export MODEL_SYNC_REGISTRY_IS_SECURE="false" && \
+	export MODEL_SYNC_REGISTRY_USER_TOKEN="$$AUTH_TOKEN" && \
+	export CONTAINER_IMAGE_URI=$$(../../scripts/get_async_upload_image.sh) && \
+	poetry install --all-extras --with integration && poetry run pytest --e2e tests/integration/ -svvv -rA --html=../../results/report.html --junit-xml=../../results/xunit_report.xml --self-contained-html -o junit_suite_name=odh-async-upload && \
+	rm -f ../../scripts/manifests/minio/.env
+
+.PHONY: test-e2e-port-cleanup
+test-e2e-odh-cleanup: undeploy-mr-odh undeploy-minio undeploy-local-kind-registry
+	@echo "Cleaning up port-forward processes..."
+	@if [ -f .port-forwards.pid ]; then \
+		kill $$(cat .port-forwards.pid) || true; \
+		rm -f .port-forwards.pid; \
+	fi

--- a/scripts/get_async_upload_image.sh
+++ b/scripts/get_async_upload_image.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Reads the async-upload job image from the model-registry-operator-parameters
+# ConfigMap in the applications namespace (from DSCInitialization).
+set -e
+
+APPS_NS=$(kubectl get dscinitializations default-dsci \
+  -o jsonpath='{.spec.applicationsNamespace}')
+
+kubectl get configmap model-registry-operator-parameters \
+  -n "$APPS_NS" \
+  -o jsonpath='{.data.IMAGES_JOBS_ASYNC_UPLOAD}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure to support end-to-end testing and automated deployment of async-upload functionality in ODH environments, with improved resource management and cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->