### PR TITLE
fix: Deploy test catalog data on ODH for sorting tests

### DIFF
--- a/catalog/clients/python/odh_rules_catalog.mk
+++ b/catalog/clients/python/odh_rules_catalog.mk
@@ -8,8 +8,13 @@ undeploy-mcp-catalog-odh:
 	@echo "Undeploying MCP catalog config on ODH..."
 	bash ../../../scripts/undeploy_catalog_on_odh.sh
 
+.PHONY: deploy-test-catalog-odh
+deploy-test-catalog-odh:
+	@echo "Deploying test catalog data on ODH..."
+	bash ../../../scripts/deploy_test_catalog_on_odh.sh
+
 .PHONY: test-e2e-catalog
-test-e2e-catalog: deploy-mcp-catalog-odh
+test-e2e-catalog: deploy-mcp-catalog-odh deploy-test-catalog-odh
 	@echo "Running catalog tests..."
 	export MC_NAMESPACE=$$(kubectl get datasciencecluster default-dsc -o jsonpath='{.spec.components.modelregistry.registriesNamespace}') && \
 	export CATALOG_URL="https://$$(kubectl get route -n "$$MC_NAMESPACE" model-catalog-https -o 'jsonpath={.status.ingress[0].host}')/" && \

--- a/scripts/deploy_test_catalog_on_odh.sh
+++ b/scripts/deploy_test_catalog_on_odh.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -e
+
+DSC_NAME="default-dsc"
+
+echo "Check if DataScienceCluster exists"
+if kubectl get datasciencecluster "$DSC_NAME" &> /dev/null; then
+  echo "DataScienceCluster '$DSC_NAME' exists."
+else
+  echo "DataScienceCluster '$DSC_NAME' does NOT exist."
+  exit 1
+fi
+
+echo "Check if Model Registry is enabled in DSC"
+MR_STATE=$(kubectl get datasciencecluster "$DSC_NAME" -o jsonpath='{.spec.components.modelregistry.managementState}' 2>/dev/null)
+if [ "$MR_STATE" != "Managed" ]; then
+  echo "Model Registry is not enabled (managementState='$MR_STATE'). Expected 'Managed'."
+  exit 1
+fi
+echo "Model Registry is enabled (managementState='Managed')."
+
+MR_NAMESPACE=$(kubectl get datasciencecluster "$DSC_NAME" -o jsonpath='{.spec.components.modelregistry.registriesNamespace}' 2>/dev/null)
+if [ -z "$MR_NAMESPACE" ]; then
+  echo "Could not determine registriesNamespace from DSC."
+  exit 1
+fi
+echo "Model Registry namespace: '$MR_NAMESPACE'"
+
+echo "Looking for catalog sources ConfigMap in namespace '$MR_NAMESPACE'"
+if kubectl get configmap mcp-catalog-sources -n "$MR_NAMESPACE" &> /dev/null; then
+  CATALOG_CONFIGMAP="mcp-catalog-sources"
+  echo "ConfigMap 'mcp-catalog-sources' found."
+elif kubectl get configmap model-catalog-sources -n "$MR_NAMESPACE" &> /dev/null; then
+  CATALOG_CONFIGMAP="model-catalog-sources"
+  echo "ConfigMap 'model-catalog-sources' found (fallback)."
+else
+  echo "Neither 'mcp-catalog-sources' nor 'model-catalog-sources' ConfigMap found in namespace '$MR_NAMESPACE'."
+  exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$(realpath "$BASH_SOURCE")")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_CATALOG_FILE="${REPO_ROOT}/manifests/kustomize/options/catalog/overlays/e2e/test-catalog.yaml"
+
+if [ ! -f "$TEST_CATALOG_FILE" ]; then
+  echo "Required file not found: $TEST_CATALOG_FILE"
+  exit 1
+fi
+
+echo "Fetching current sources.yaml from ConfigMap"
+CURRENT_SOURCES=$(kubectl get configmap "$CATALOG_CONFIGMAP" -n "$MR_NAMESPACE" -o jsonpath='{.data.sources\.yaml}')
+
+if echo "$CURRENT_SOURCES" | grep -q "test_catalog"; then
+  echo "test_catalog already present in sources.yaml, skipping patch."
+else
+  echo "Patching ConfigMap to add test catalog source"
+
+  TEST_CATALOG_CONTENT=$(cat "$TEST_CATALOG_FILE")
+
+  TEST_CATALOG_ENTRY="
+catalogs:
+  - name: Test Catalog
+    id: test_catalog
+    type: yaml
+    enabled: true
+    properties:
+      yamlCatalogPath: test-catalog.yaml
+    labels:
+      - Test Catalog
+"
+
+  if echo "$CURRENT_SOURCES" | grep -q "catalogs: \[\]"; then
+    # Replace empty catalogs: [] with test catalog entry
+    UPDATED_SOURCES=$(echo "$CURRENT_SOURCES" | sed 's/catalogs: \[\]//')
+    UPDATED_SOURCES="${UPDATED_SOURCES}${TEST_CATALOG_ENTRY}"
+  elif echo "$CURRENT_SOURCES" | grep -q "^catalogs:"; then
+    # Append to existing catalogs section
+    UPDATED_SOURCES=$(echo "$CURRENT_SOURCES" | sed '/^catalogs:/a\
+  - name: Test Catalog\
+    id: test_catalog\
+    type: yaml\
+    enabled: true\
+    properties:\
+      yamlCatalogPath: test-catalog.yaml\
+    labels:\
+      - Test Catalog')
+  else
+    # No catalogs section exists, append one
+    UPDATED_SOURCES="${CURRENT_SOURCES}${TEST_CATALOG_ENTRY}"
+  fi
+
+  # Patch the existing ConfigMap: update sources.yaml and add the test catalog YAML as a data key
+  kubectl patch configmap "$CATALOG_CONFIGMAP" -n "$MR_NAMESPACE" --type merge -p "$(cat <<EOF
+{"data": {"sources.yaml": $(echo "$UPDATED_SOURCES" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'), "test-catalog.yaml": $(echo "$TEST_CATALOG_CONTENT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}}
+EOF
+)"
+
+  echo "ConfigMap '$CATALOG_CONFIGMAP' patched successfully."
+
+  echo "Restarting model-catalog pod to pick up config changes"
+  CATALOG_DEPLOYMENT=$(kubectl get deployment -n "$MR_NAMESPACE" -l app.kubernetes.io/name=model-catalog -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+  if [ -z "$CATALOG_DEPLOYMENT" ]; then
+    echo "Could not find model-catalog deployment in namespace '$MR_NAMESPACE'."
+    exit 1
+  fi
+  kubectl delete pod -l app.kubernetes.io/name=model-catalog -n "$MR_NAMESPACE" --wait=true
+  kubectl wait --for=condition=Available deployment/"$CATALOG_DEPLOYMENT" -n "$MR_NAMESPACE" --timeout=5m
+  echo "model-catalog pod is ready."
+fi


### PR DESCRIPTION
Signed-off-by: Debarati Basu-Nag <dbasunag@redhat.com>

AI-assisted: Claude Code (Opus 4.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated deployment of a test catalog to the ODH environment and ensured the model catalog is refreshed before test runs.
* **Tests**
  * Updated end-to-end test setup so E2E runs now depend on the test catalog being deployed, guaranteeing required test data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->