### PR TITLE
feat: set NextProtos on all TLS configs (server and client)

### DIFF
--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -101,6 +101,7 @@ func main() {
 			// Configure TLS if both cert and key files are provided
 			tlsConfig := &tls.Config{
 				MinVersion: tls.VersionTLS13,
+				NextProtos: []string{"h2", "http/1.1"},
 			}
 			srv.TLSConfig = tlsConfig
 			err = srv.ListenAndServeTLS(certFile, keyFile)

--- a/clients/ui/bff/internal/integrations/httpclient/http.go
+++ b/clients/ui/bff/internal/integrations/httpclient/http.go
@@ -43,7 +43,10 @@ func (e *HTTPError) Error() string {
 }
 
 func NewHTTPClient(logger *slog.Logger, baseURL string, headers http.Header, insecureSkipVerify bool, rootCAs *x509.CertPool) (HTTPClientInterface, error) {
-	tlsCfg := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+		NextProtos:         []string{"h2", "http/1.1"},
+	}
 	if rootCAs != nil {
 		tlsCfg.RootCAs = rootCAs
 	}

--- a/internal/platform/tls/config.go
+++ b/internal/platform/tls/config.go
@@ -65,6 +65,7 @@ func (c *TLSConfig) BuildTLSConfig() (*tls.Config, error) {
 		RootCAs:            rootCAs,
 		InsecureSkipVerify: !c.VerifyServerCert,
 		MinVersion:         tls.VersionTLS12,
+		NextProtos:         []string{"h2", "http/1.1"},
 	}
 
 	if c.CertPath != "" && c.KeyPath != "" {

--- a/pkg/inferenceservice-controller/controller.go
+++ b/pkg/inferenceservice-controller/controller.go
@@ -52,7 +52,10 @@ func NewInferenceServiceController(
 
 	if skipTLSVerify {
 		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"h2", "http/1.1"},
+			},
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add ALPN negotiation (`h2`, `http/1.1`) to all TLS configurations across the codebase
- Covers BFF HTTP client, InferenceService controller HTTP client, BFF server TLS, and shared TLS config builder (`internal/tls/config.go`)
- Ensures proper HTTP/2 negotiation on OpenShift clusters where ALPN is required by the serving infrastructure

## Files changed
- `clients/ui/bff/internal/integrations/httpclient/http.go` - BFF outbound HTTP client TLS config
- `pkg/inferenceservice-controller/controller.go` - InferenceService controller HTTP client TLS config
- `clients/ui/bff/cmd/main.go` - BFF server-side TLS config
- `internal/tls/config.go` - shared `BuildTLSConfig()` used across the codebase

## Test plan
- [x] `go build ./...` passes
- [ ] Verify BFF connects to model-registry over TLS on OpenShift
- [ ] Verify InferenceService controller can reach model-registry API over TLS

Ref: [RHOAIENG-61382](https://redhat.atlassian.net/browse/RHOAIENG-61382)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Updated TLS protocol negotiation across service components to support HTTP/2 alongside HTTP/1.1, enhancing protocol compatibility during secure communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->